### PR TITLE
fix: entrypoint passes command through for worker container

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,5 +4,10 @@ set -e
 # Run database migrations
 alembic upgrade head
 
-# Start the application
-exec uvicorn app.main:app --host 0.0.0.0 --port 8000 "$@"
+# If a command is provided (e.g. celery worker), run it directly.
+# Otherwise, start the default uvicorn server.
+if [ $# -gt 0 ]; then
+    exec "$@"
+else
+    exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+fi


### PR DESCRIPTION
The entrypoint always ran `uvicorn ... "$@"`, so the worker's celery command was passed as args to uvicorn (causing `No such option: -A`). Now if a command is provided (docker-compose `command:`), it runs directly; otherwise falls back to uvicorn for the API container.

Also stamped alembic_version in the production DB to fix the `DuplicateTable` crash (tables existed from create_all() but alembic had never been stamped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend deployment flexibility to support custom commands while maintaining default server operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->