### PR TITLE
Add comprehensive test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ htmlcov/
 data/
 frontend/test-results/
 .scannerwork/
+frontend/playwright-report/

--- a/backend/tests/test_animations_more.py
+++ b/backend/tests/test_animations_more.py
@@ -1,0 +1,101 @@
+"""Additional animation and crop preset tests."""
+
+import pytest
+from app.db.models import GoesFrame
+from datetime import datetime
+
+
+@pytest.mark.asyncio
+async def test_crop_preset_crud(client):
+    # Create
+    resp = await client.post("/api/goes/crop-presets", json={
+        "name": "Full HD", "x": 0, "y": 0, "width": 1920, "height": 1080,
+    })
+    assert resp.status_code == 200
+    pid = resp.json()["id"]
+
+    # List
+    resp = await client.get("/api/goes/crop-presets")
+    assert len(resp.json()) == 1
+
+    # Update
+    resp = await client.put(f"/api/goes/crop-presets/{pid}", json={"name": "4K"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "4K"
+
+    # Delete
+    resp = await client.delete(f"/api/goes/crop-presets/{pid}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_crop_preset_duplicate_name(client):
+    await client.post("/api/goes/crop-presets", json={
+        "name": "dup", "x": 0, "y": 0, "width": 100, "height": 100,
+    })
+    resp = await client.post("/api/goes/crop-presets", json={
+        "name": "dup", "x": 0, "y": 0, "width": 200, "height": 200,
+    })
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent_crop_preset(client):
+    resp = await client.put("/api/goes/crop-presets/fake", json={"name": "x"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_crop_preset(client):
+    resp = await client.delete("/api/goes/crop-presets/fake")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_animations_list_empty(client):
+    resp = await client.get("/api/goes/animations")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_animation_detail_not_found(client):
+    resp = await client.get("/api/goes/animations/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_animation(client):
+    resp = await client.delete("/api/goes/animations/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_animation_no_frames(client):
+    resp = await client.post("/api/goes/animations", json={
+        "name": "test", "frame_ids": [], "fps": 24, "format": "mp4",
+    })
+    assert resp.status_code in (400, 422)
+
+
+@pytest.mark.asyncio
+async def test_animations_pagination(client):
+    resp = await client.get("/api/goes/animations?page=1&limit=5")
+    assert resp.status_code == 200
+    assert resp.json()["limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_crop_preset_partial_update(client):
+    resp = await client.post("/api/goes/crop-presets", json={
+        "name": "test", "x": 0, "y": 0, "width": 100, "height": 100,
+    })
+    pid = resp.json()["id"]
+
+    # Update only width
+    resp = await client.put(f"/api/goes/crop-presets/{pid}", json={"width": 500})
+    assert resp.status_code == 200
+    assert resp.json()["width"] == 500
+    assert resp.json()["height"] == 100  # unchanged

--- a/backend/tests/test_errors_unit.py
+++ b/backend/tests/test_errors_unit.py
@@ -1,0 +1,46 @@
+"""Unit tests for error handling module."""
+
+import pytest
+from fastapi import Request
+from starlette.testclient import TestClient
+
+from app.errors import APIError, api_error_handler
+
+
+class TestAPIError:
+    def test_attributes(self):
+        err = APIError(404, "not_found", "Item missing")
+        assert err.status_code == 404
+        assert err.error == "not_found"
+        assert err.detail == "Item missing"
+
+    def test_default_detail(self):
+        err = APIError(500, "internal")
+        assert err.detail == ""
+
+    def test_is_exception(self):
+        err = APIError(400, "bad_request")
+        assert isinstance(err, Exception)
+
+
+@pytest.mark.asyncio
+async def test_api_error_handler_response():
+    """Verify the handler returns correct JSON structure."""
+    exc = APIError(422, "validation_error", "bad field")
+    # Create a mock request
+    scope = {"type": "http", "method": "GET", "path": "/test"}
+    request = Request(scope)
+    response = api_error_handler(request, exc)
+    assert response.status_code == 422
+    assert response.body == b'{"error":"validation_error","detail":"bad field"}'
+
+
+@pytest.mark.asyncio
+async def test_api_error_handler_empty_detail():
+    exc = APIError(500, "internal")
+    scope = {"type": "http", "method": "GET", "path": "/test"}
+    request = Request(scope)
+    response = api_error_handler(request, exc)
+    assert response.status_code == 500
+    body = response.body.decode()
+    assert '"detail":""' in body

--- a/backend/tests/test_goes_data_more.py
+++ b/backend/tests/test_goes_data_more.py
@@ -1,0 +1,198 @@
+"""Additional GOES data tests — frames, collections, tags edge cases."""
+
+import pytest
+from app.db.models import GoesFrame, Collection, Tag
+from datetime import datetime
+
+
+@pytest.mark.asyncio
+async def test_frames_empty(client):
+    resp = await client.get("/api/goes/frames")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_frames_pagination(client, db):
+    for i in range(5):
+        db.add(GoesFrame(
+            id=f"f{i}", satellite="GOES-16", sector="CONUS", band="C02",
+            capture_time=datetime(2024, 1, 1, i), file_path=f"/t/{i}.nc", file_size=100,
+        ))
+    await db.commit()
+
+    resp = await client.get("/api/goes/frames?page=1&limit=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["items"]) == 2
+    assert data["total"] == 5
+
+
+@pytest.mark.asyncio
+async def test_frames_filter_satellite(client, db):
+    db.add(GoesFrame(id="f1", satellite="GOES-16", sector="CONUS", band="C02",
+                     capture_time=datetime(2024, 1, 1), file_path="/t/1.nc", file_size=100))
+    db.add(GoesFrame(id="f2", satellite="GOES-18", sector="CONUS", band="C02",
+                     capture_time=datetime(2024, 1, 1), file_path="/t/2.nc", file_size=100))
+    await db.commit()
+
+    resp = await client.get("/api/goes/frames?satellite=GOES-16")
+    assert resp.json()["total"] == 1
+    assert resp.json()["items"][0]["satellite"] == "GOES-16"
+
+
+@pytest.mark.asyncio
+async def test_frames_sort_asc(client, db):
+    for i in [3, 1, 2]:
+        db.add(GoesFrame(id=f"f{i}", satellite="GOES-16", sector="CONUS", band="C02",
+                         capture_time=datetime(2024, 1, 1, i), file_path=f"/t/{i}.nc", file_size=i*100))
+    await db.commit()
+
+    resp = await client.get("/api/goes/frames?sort=file_size&order=asc")
+    items = resp.json()["items"]
+    sizes = [it["file_size"] for it in items]
+    assert sizes == sorted(sizes)
+
+
+@pytest.mark.asyncio
+async def test_frame_detail_not_found(client):
+    resp = await client.get("/api/goes/frames/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_frame_detail(client, db):
+    db.add(GoesFrame(id="f1", satellite="GOES-16", sector="CONUS", band="C02",
+                     capture_time=datetime(2024, 1, 1), file_path="/t/1.nc", file_size=100))
+    await db.commit()
+
+    resp = await client.get("/api/goes/frames/f1")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "f1"
+
+
+@pytest.mark.asyncio
+async def test_frame_stats_empty(client):
+    resp = await client.get("/api/goes/frames/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_frames"] == 0
+    assert data["total_size_bytes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_frame_stats_with_data(client, db):
+    db.add(GoesFrame(id="f1", satellite="GOES-16", sector="CONUS", band="C02",
+                     capture_time=datetime(2024, 1, 1), file_path="/t/1.nc", file_size=500))
+    db.add(GoesFrame(id="f2", satellite="GOES-18", sector="CONUS", band="C13",
+                     capture_time=datetime(2024, 1, 1), file_path="/t/2.nc", file_size=300))
+    await db.commit()
+
+    resp = await client.get("/api/goes/frames/stats")
+    data = resp.json()
+    assert data["total_frames"] == 2
+    assert data["total_size_bytes"] == 800
+    assert "GOES-16" in data["by_satellite"]
+    assert "C02" in data["by_band"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_empty_ids(client):
+    resp = await client.request("DELETE", "/api/goes/frames", json={"ids": []})
+    assert resp.status_code in (200, 422)
+
+
+@pytest.mark.asyncio
+async def test_collection_crud(client):
+    # Create
+    resp = await client.post("/api/goes/collections", json={"name": "Test Col", "description": "desc"})
+    assert resp.status_code == 200
+    coll_id = resp.json()["id"]
+    assert resp.json()["name"] == "Test Col"
+
+    # List
+    resp = await client.get("/api/goes/collections")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # Update
+    resp = await client.put(f"/api/goes/collections/{coll_id}", json={"name": "Renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"
+
+    # Delete
+    resp = await client.delete(f"/api/goes/collections/{coll_id}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent_collection(client):
+    resp = await client.put("/api/goes/collections/fake", json={"name": "x"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_collection(client):
+    resp = await client.delete("/api/goes/collections/fake")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_add_frames_to_nonexistent_collection(client):
+    resp = await client.post("/api/goes/collections/fake/frames", json={"frame_ids": ["f1"]})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_tag_crud(client):
+    # Create
+    resp = await client.post("/api/goes/tags", json={"name": "urgent", "color": "#ff0000"})
+    assert resp.status_code == 200
+    tag_id = resp.json()["id"]
+    assert resp.json()["name"] == "urgent"
+
+    # List
+    resp = await client.get("/api/goes/tags")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # Delete
+    resp = await client.delete(f"/api/goes/tags/{tag_id}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_duplicate_tag(client):
+    await client.post("/api/goes/tags", json={"name": "dup", "color": "#000"})
+    resp = await client.post("/api/goes/tags", json={"name": "dup", "color": "#111"})
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_tag(client):
+    resp = await client.delete("/api/goes/tags/fake")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_process_frames_no_match(client):
+    resp = await client.post("/api/goes/frames/process", json={
+        "frame_ids": ["nonexistent"],
+        "params": {},
+    })
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_frames_date_filter(client, db):
+    db.add(GoesFrame(id="f1", satellite="GOES-16", sector="CONUS", band="C02",
+                     capture_time=datetime(2024, 1, 1), file_path="/t/1.nc", file_size=100))
+    db.add(GoesFrame(id="f2", satellite="GOES-16", sector="CONUS", band="C02",
+                     capture_time=datetime(2024, 6, 1), file_path="/t/2.nc", file_size=100))
+    await db.commit()
+
+    resp = await client.get("/api/goes/frames?start_date=2024-03-01T00:00:00")
+    assert resp.json()["total"] == 1
+    assert resp.json()["items"][0]["id"] == "f2"

--- a/backend/tests/test_goes_more.py
+++ b/backend/tests/test_goes_more.py
@@ -1,0 +1,200 @@
+"""Additional GOES router tests — edge cases, composites, latest, preview."""
+
+import pytest
+from app.db.models import GoesFrame
+from datetime import datetime
+
+
+@pytest.mark.asyncio
+async def test_products_structure(client):
+    resp = await client.get("/api/goes/products")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "satellites" in data
+    assert "sectors" in data
+    assert "bands" in data
+    assert len(data["satellites"]) > 0
+    assert len(data["bands"]) == 16
+    # Each band should have id and description
+    for band in data["bands"]:
+        assert "id" in band
+        assert "description" in band
+
+
+@pytest.mark.asyncio
+async def test_latest_frame_not_found(client):
+    resp = await client.get("/api/goes/latest?satellite=GOES-16&sector=CONUS&band=C02")
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_latest_frame_found(client, db):
+    frame = GoesFrame(
+        id="f1",
+        satellite="GOES-16",
+        sector="CONUS",
+        band="C02",
+        capture_time=datetime(2024, 1, 1, 12, 0),
+        file_path="/tmp/test.nc",
+        file_size=1000,
+    )
+    db.add(frame)
+    await db.commit()
+
+    resp = await client.get("/api/goes/latest?satellite=GOES-16&sector=CONUS&band=C02")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "f1"
+    assert data["satellite"] == "GOES-16"
+
+
+@pytest.mark.asyncio
+async def test_latest_returns_most_recent(client, db):
+    for i, hour in enumerate([10, 12, 11]):
+        db.add(GoesFrame(
+            id=f"f{i}", satellite="GOES-16", sector="CONUS", band="C02",
+            capture_time=datetime(2024, 1, 1, hour, 0),
+            file_path=f"/tmp/t{i}.nc", file_size=100,
+        ))
+    await db.commit()
+
+    resp = await client.get("/api/goes/latest?satellite=GOES-16&sector=CONUS&band=C02")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "f1"  # hour=12 is most recent
+
+
+@pytest.mark.asyncio
+async def test_composite_recipes_list(client):
+    resp = await client.get("/api/goes/composite-recipes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 6
+    names = {r["id"] for r in data}
+    assert "true_color" in names
+    assert "fire_detection" in names
+
+
+@pytest.mark.asyncio
+async def test_create_composite_missing_recipe(client):
+    resp = await client.post("/api/goes/composites", json={
+        "satellite": "GOES-16", "sector": "CONUS",
+        "capture_time": "2024-01-01T12:00:00",
+    })
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_composites_list_empty(client):
+    resp = await client.get("/api/goes/composites")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_composites_pagination(client):
+    resp = await client.get("/api/goes/composites?page=1&limit=5")
+    assert resp.status_code == 200
+    assert resp.json()["limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_composite_detail_not_found(client):
+    resp = await client.get("/api/goes/composites/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_gaps_endpoint(client):
+    resp = await client.get("/api/goes/gaps")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_gaps_with_filters(client):
+    resp = await client.get("/api/goes/gaps?satellite=GOES-16&band=C02&expected_interval=15.0")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_gaps_invalid_interval(client):
+    resp = await client.get("/api/goes/gaps?expected_interval=0.1")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_health_version(client):
+    resp = await client.get("/api/health/version")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "version" in data
+    assert "build" in data
+
+
+@pytest.mark.asyncio
+async def test_settings_update_crop(client):
+    resp = await client.put("/api/settings", json={
+        "default_crop": {"x": 10, "y": 20, "w": 800, "h": 600}
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["default_crop"]["x"] == 10
+
+
+@pytest.mark.asyncio
+async def test_settings_update_false_color(client):
+    resp = await client.put("/api/settings", json={"default_false_color": "fire"})
+    assert resp.status_code == 200
+    assert resp.json()["default_false_color"] == "fire"
+
+
+@pytest.mark.asyncio
+async def test_settings_invalid_false_color(client):
+    resp = await client.put("/api/settings", json={"default_false_color": "invalid"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_settings_update_codec(client):
+    for codec in ["h264", "hevc", "av1"]:
+        resp = await client.put("/api/settings", json={"video_codec": codec})
+        assert resp.status_code == 200
+        assert resp.json()["video_codec"] == codec
+
+
+@pytest.mark.asyncio
+async def test_settings_invalid_codec(client):
+    resp = await client.put("/api/settings", json={"video_codec": "mpeg4"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_settings_quality_boundary(client):
+    resp = await client.put("/api/settings", json={"video_quality": 0})
+    assert resp.status_code == 200
+    resp = await client.put("/api/settings", json={"video_quality": 51})
+    assert resp.status_code == 200
+    resp = await client.put("/api/settings", json={"video_quality": 52})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_settings_fps_boundary(client):
+    resp = await client.put("/api/settings", json={"video_fps": 1})
+    assert resp.status_code == 200
+    resp = await client.put("/api/settings", json={"video_fps": 120})
+    assert resp.status_code == 200
+    resp = await client.put("/api/settings", json={"video_fps": 121})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_settings_timestamp_position(client):
+    for pos in ["top-left", "top-right", "bottom-left", "bottom-right"]:
+        resp = await client.put("/api/settings", json={"timestamp_position": pos})
+        assert resp.status_code == 200
+    resp = await client.put("/api/settings", json={"timestamp_position": "center"})
+    assert resp.status_code == 422

--- a/backend/tests/test_scheduling_more.py
+++ b/backend/tests/test_scheduling_more.py
@@ -1,0 +1,74 @@
+"""Additional scheduling router tests — fetch presets, schedules, cleanup rules."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_fetch_preset_crud(client):
+    # Create
+    resp = await client.post("/api/goes/fetch-presets", json={
+        "name": "Morning CONUS", "satellite": "GOES-16", "sector": "CONUS",
+        "band": "C02", "description": "Morning fetch",
+    })
+    assert resp.status_code == 200
+    pid = resp.json()["id"]
+    assert resp.json()["name"] == "Morning CONUS"
+
+    # List
+    resp = await client.get("/api/goes/fetch-presets")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # Update
+    resp = await client.put(f"/api/goes/fetch-presets/{pid}", json={"name": "Evening"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Evening"
+
+    # Delete
+    resp = await client.delete(f"/api/goes/fetch-presets/{pid}")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == pid
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent_fetch_preset(client):
+    resp = await client.put("/api/goes/fetch-presets/fake", json={"name": "x"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_fetch_preset(client):
+    resp = await client.delete("/api/goes/fetch-presets/fake")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_fetch_preset_partial_update(client):
+    resp = await client.post("/api/goes/fetch-presets", json={
+        "name": "Test", "satellite": "GOES-16", "sector": "CONUS", "band": "C02",
+    })
+    pid = resp.json()["id"]
+
+    resp = await client.put(f"/api/goes/fetch-presets/{pid}", json={"band": "C13"})
+    assert resp.status_code == 200
+    assert resp.json()["band"] == "C13"
+    assert resp.json()["satellite"] == "GOES-16"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_fetch_presets_list_empty(client):
+    resp = await client.get("/api/goes/fetch-presets")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_fetch_presets(client):
+    for i in range(3):
+        resp = await client.post("/api/goes/fetch-presets", json={
+            "name": f"Preset {i}", "satellite": "GOES-16", "sector": "CONUS", "band": "C02",
+        })
+        assert resp.status_code == 200
+
+    resp = await client.get("/api/goes/fetch-presets")
+    assert len(resp.json()) == 3

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,28 @@
+"""Tests for utility functions."""
+
+from datetime import datetime
+
+import pytest
+
+from app.utils import utcnow
+
+
+class TestUtcNow:
+    def test_returns_datetime(self):
+        result = utcnow()
+        assert isinstance(result, datetime)
+
+    def test_naive_no_tzinfo(self):
+        result = utcnow()
+        assert result.tzinfo is None
+
+    def test_reasonable_time(self):
+        before = utcnow()
+        result = utcnow()
+        after = utcnow()
+        assert before <= result <= after
+
+    def test_different_calls_are_close(self):
+        a = utcnow()
+        b = utcnow()
+        assert abs((b - a).total_seconds()) < 1.0

--- a/frontend/e2e/goes-data.spec.ts
+++ b/frontend/e2e/goes-data.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+const mockApiHandler = async (route: any) => {
+  const url = route.request().url();
+  if (url.includes('/api/health')) return route.fulfill({ json: { status: 'ok' } });
+  if (url.includes('/api/goes/frames/stats')) {
+    return route.fulfill({
+      json: { total_frames: 100, total_size_bytes: 5000000, by_satellite: {}, by_band: {} },
+    });
+  }
+  if (url.includes('/api/goes/frames')) {
+    return route.fulfill({ json: { items: [], total: 0, page: 1, limit: 50 } });
+  }
+  if (url.includes('/api/goes/collections')) return route.fulfill({ json: [] });
+  if (url.includes('/api/goes/tags')) return route.fulfill({ json: [] });
+  if (url.includes('/api/goes/products')) {
+    return route.fulfill({
+      json: {
+        satellites: ['GOES-16', 'GOES-18'],
+        sectors: [{ id: 'CONUS', name: 'CONUS', product: 'ABI-L2-CMIPF' }],
+        bands: [{ id: 'C02', description: 'Red (0.64µm)' }],
+      },
+    });
+  }
+  if (url.includes('/api/goes/fetch-presets')) return route.fulfill({ json: [] });
+  if (url.includes('/api/goes/crop-presets')) return route.fulfill({ json: [] });
+  if (url.includes('/api/goes/animations')) {
+    return route.fulfill({ json: { items: [], total: 0, page: 1, limit: 20 } });
+  }
+  if (url.includes('/api/goes/cleanup-rules')) return route.fulfill({ json: [] });
+  if (url.includes('/api/goes/schedules')) return route.fulfill({ json: [] });
+  if (url.includes('/api/goes/composite-recipes')) {
+    return route.fulfill({ json: [{ id: 'true_color', name: 'True Color', bands: ['C02', 'C03', 'C01'] }] });
+  }
+  if (url.includes('/api/goes/composites')) {
+    return route.fulfill({ json: { items: [], total: 0, page: 1, limit: 20 } });
+  }
+  if (url.includes('/api/system/status')) {
+    return route.fulfill({
+      json: { cpu_percent: 10, memory: { total: 16e9, available: 12e9, percent: 25 }, disk: { total: 500e9, free: 400e9, percent: 20 } },
+    });
+  }
+  if (url.includes('/api/stats')) {
+    return route.fulfill({ json: { total_images: 0, total_jobs: 0, active_jobs: 0, storage_used_mb: 0 } });
+  }
+  if (url.includes('/api/settings')) return route.fulfill({ json: { video_fps: 24, video_codec: 'h264' } });
+  if (url.includes('/api/presets')) return route.fulfill({ json: [] });
+  return route.continue();
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/**', mockApiHandler);
+});
+
+test('GOES data page loads', async ({ page }) => {
+  await page.goto('/goes');
+  await expect(page.locator('text=/GOES/i').first()).toBeVisible();
+});
+
+test('navigate to GOES data from sidebar', async ({ page }) => {
+  await page.goto('/');
+  const goesLink = page.locator('a[href="/goes"]').first();
+  if (await goesLink.isVisible()) {
+    await goesLink.click();
+    await expect(page).toHaveURL(/goes/);
+  }
+});

--- a/frontend/e2e/theme.spec.ts
+++ b/frontend/e2e/theme.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url();
+    if (url.includes('/api/health')) return route.fulfill({ json: { status: 'ok' } });
+    if (url.includes('/api/stats')) return route.fulfill({ json: { total_images: 0, total_jobs: 0, active_jobs: 0, storage_used_mb: 0 } });
+    if (url.includes('/api/system/status')) {
+      return route.fulfill({ json: { cpu_percent: 10, memory: { total: 16e9, available: 12e9, percent: 25 }, disk: { total: 500e9, free: 400e9, percent: 20 } } });
+    }
+    if (url.includes('/api/images')) return route.fulfill({ json: { items: [], total: 0, page: 1, limit: 20 } });
+    if (url.includes('/api/jobs')) return route.fulfill({ json: { items: [], total: 0, page: 1, limit: 20 } });
+    if (url.includes('/api/settings')) return route.fulfill({ json: { video_fps: 24, video_codec: 'h264' } });
+    if (url.includes('/api/presets')) return route.fulfill({ json: [] });
+    return route.continue();
+  });
+});
+
+test('page loads with dark theme by default', async ({ page }) => {
+  await page.goto('/');
+  // The app uses dark mode by default (space theme)
+  const html = page.locator('html');
+  const className = await html.getAttribute('class');
+  // Should have dark class or no light class
+  expect(className?.includes('light')).toBeFalsy();
+});
+
+test('mobile viewport renders sidebar differently', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/');
+  // Page should still load on mobile
+  await expect(page.locator('text=Dashboard').first()).toBeVisible();
+});

--- a/frontend/src/test/Breadcrumb.test.tsx
+++ b/frontend/src/test/Breadcrumb.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Breadcrumb from '../components/GoesData/Breadcrumb';
+
+describe('Breadcrumb', () => {
+  it('returns null for single segment', () => {
+    const { container } = render(<Breadcrumb segments={[{ label: 'Home' }]} />);
+    expect(container.querySelector('nav')).toBeNull();
+  });
+
+  it('renders multiple segments', () => {
+    render(
+      <Breadcrumb segments={[
+        { label: 'Home', onClick: vi.fn() },
+        { label: 'Data' },
+      ]} />
+    );
+    expect(screen.getByText('Home')).toBeTruthy();
+    expect(screen.getByText('Data')).toBeTruthy();
+  });
+
+  it('clickable segments fire onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <Breadcrumb segments={[
+        { label: 'Home', onClick },
+        { label: 'Current' },
+      ]} />
+    );
+    fireEvent.click(screen.getByText('Home'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('last segment is not clickable', () => {
+    render(
+      <Breadcrumb segments={[
+        { label: 'Home', onClick: vi.fn() },
+        { label: 'Current' },
+      ]} />
+    );
+    const last = screen.getByText('Current');
+    expect(last.tagName).toBe('SPAN');
+  });
+
+  it('has aria-label', () => {
+    render(
+      <Breadcrumb segments={[{ label: 'A', onClick: vi.fn() }, { label: 'B' }]} />
+    );
+    expect(screen.getByLabelText('Breadcrumb')).toBeTruthy();
+  });
+});

--- a/frontend/src/test/EmptyState.test.tsx
+++ b/frontend/src/test/EmptyState.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EmptyState from '../components/GoesData/EmptyState';
+import { AlertCircle } from 'lucide-react';
+
+describe('EmptyState', () => {
+  it('renders title and description', () => {
+    render(<EmptyState icon={<AlertCircle />} title="No data" description="Nothing here" />);
+    expect(screen.getByText('No data')).toBeTruthy();
+    expect(screen.getByText('Nothing here')).toBeTruthy();
+  });
+
+  it('renders action button when provided', () => {
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        icon={<AlertCircle />}
+        title="Empty"
+        description="Desc"
+        action={{ label: 'Add', onClick }}
+      />
+    );
+    const btn = screen.getByText('Add');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('does not render action button when not provided', () => {
+    render(<EmptyState icon={<AlertCircle />} title="Empty" description="Desc" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/frontend/src/test/KeyboardShortcuts.test.tsx
+++ b/frontend/src/test/KeyboardShortcuts.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import KeyboardShortcuts from '../components/KeyboardShortcuts';
+
+vi.mock('../hooks/useHotkeys', () => ({
+  useHotkeys: vi.fn(),
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe('KeyboardShortcuts', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(<KeyboardShortcuts />, { wrapper });
+    expect(container.querySelector('dialog')).toBeNull();
+  });
+});

--- a/frontend/src/test/Skeleton.test.tsx
+++ b/frontend/src/test/Skeleton.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Skeleton from '../components/GoesData/Skeleton';
+
+describe('Skeleton', () => {
+  it('renders single text skeleton by default', () => {
+    const { container } = render(<Skeleton />);
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('renders multiple items', () => {
+    const { container } = render(<Skeleton count={3} />);
+    const items = container.querySelectorAll('.animate-pulse');
+    expect(items.length).toBe(3);
+  });
+
+  it('renders card variant', () => {
+    const { container } = render(<Skeleton variant="card" />);
+    expect(container.querySelector('.aspect-video')).toBeTruthy();
+  });
+
+  it('renders thumbnail variant', () => {
+    const { container } = render(<Skeleton variant="thumbnail" />);
+    expect(container.querySelector('.aspect-video')).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Skeleton className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeTruthy();
+  });
+});

--- a/frontend/src/test/TabErrorBoundary.test.tsx
+++ b/frontend/src/test/TabErrorBoundary.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TabErrorBoundary from '../components/GoesData/TabErrorBoundary';
+
+function ThrowingChild() {
+  throw new Error('Test crash');
+}
+
+describe('TabErrorBoundary', () => {
+  // Suppress console.error for expected errors
+  const originalError = console.error;
+  beforeEach(() => { console.error = vi.fn(); });
+  afterEach(() => { console.error = originalError; });
+
+  it('renders children when no error', () => {
+    render(
+      <TabErrorBoundary tabName="Browse">
+        <div>Content</div>
+      </TabErrorBoundary>
+    );
+    expect(screen.getByText('Content')).toBeTruthy();
+  });
+
+  it('shows error UI when child throws', () => {
+    render(
+      <TabErrorBoundary tabName="Browse">
+        <ThrowingChild />
+      </TabErrorBoundary>
+    );
+    expect(screen.getByText(/Browse encountered an error/)).toBeTruthy();
+    expect(screen.getByText('Test crash')).toBeTruthy();
+  });
+
+  it('shows retry button', () => {
+    render(
+      <TabErrorBoundary tabName="Test">
+        <ThrowingChild />
+      </TabErrorBoundary>
+    );
+    expect(screen.getByText('Retry')).toBeTruthy();
+  });
+
+  it('uses default tab name when not provided', () => {
+    render(
+      <TabErrorBoundary>
+        <ThrowingChild />
+      </TabErrorBoundary>
+    );
+    expect(screen.getByText(/This tab encountered an error/)).toBeTruthy();
+  });
+});

--- a/frontend/src/test/Toast.test.tsx
+++ b/frontend/src/test/Toast.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ToastContainer from '../components/Toast';
+
+describe('ToastContainer', () => {
+  it('renders nothing when no toasts', () => {
+    const { container } = render(<ToastContainer />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/src/test/VideoPlayer.test.tsx
+++ b/frontend/src/test/VideoPlayer.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VideoPlayer from '../components/VideoPlayer/VideoPlayer';
+
+describe('VideoPlayer', () => {
+  it('renders video element', () => {
+    const { container } = render(<VideoPlayer src="/test.mp4" />);
+    const video = container.querySelector('video');
+    expect(video).toBeTruthy();
+    expect(video?.getAttribute('src')).toBe('/test.mp4');
+  });
+
+  it('shows error state on video error', () => {
+    const { container } = render(<VideoPlayer src="/bad.mp4" />);
+    const video = container.querySelector('video');
+    fireEvent.error(video!);
+    expect(screen.getByText('Video failed to load')).toBeTruthy();
+  });
+
+  it('has controls attribute', () => {
+    const { container } = render(<VideoPlayer src="/test.mp4" />);
+    const video = container.querySelector('video');
+    expect(video?.hasAttribute('controls')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Test Coverage Improvements

### Backend (64 new tests → 462 total)
- **test_utils.py**: `utcnow()` helper — returns naive datetime, no tzinfo, reasonable values
- **test_errors_unit.py**: `APIError` class attributes, `api_error_handler` JSON response structure
- **test_goes_more.py**: Products structure, latest frame (found/not found/most recent), composite recipes, composites CRUD, gaps endpoint with filters/validation, health version, settings edge cases (crop, false_color, codec, quality/fps boundaries, timestamp positions)
- **test_goes_data_more.py**: Frames listing/pagination/filtering/sorting, frame detail, frame stats, bulk delete, collection CRUD + edge cases, tag CRUD + duplicates, process frames, date filtering
- **test_animations_more.py**: Crop preset CRUD + duplicates + partial updates, animations list/detail/delete, pagination
- **test_scheduling_more.py**: Fetch preset CRUD + partial updates, list empty, multiple presets

### Frontend Unit (22 new tests → 120 total)
- **EmptyState**: Renders title/description, action button click, no button when absent
- **Skeleton**: Text/card/thumbnail variants, count, custom className
- **Breadcrumb**: Single segment (null), multiple segments, clickable, aria-label
- **TabErrorBoundary**: Normal render, error UI with tab name, retry button, default name
- **VideoPlayer**: Renders video, error state on load failure, controls attribute
- **Toast**: Renders nothing when empty
- **KeyboardShortcuts**: Renders nothing when closed

### E2E (4 new tests → 23 total)
- GOES Data page loads and sidebar navigation
- Dark theme verification
- Mobile responsive viewport (375x667)

All backend tests pass ✅ All frontend unit tests pass ✅