### PR TITLE
fix: dark mode card backgrounds not applying

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -263,7 +263,7 @@ header {
 }
 
 /* Light mode glass */
-:not(.dark) .glass-card {
+:root:not(.dark) .glass-card {
   background: color-mix(in srgb, white 75%, transparent);
 }
 
@@ -296,20 +296,20 @@ header {
 }
 
 /* === Light mode overrides === */
-:not(.dark) .bg-card {
+:root:not(.dark) .bg-card {
   background-color: #ffffff;
 }
 
-:not(.dark) .border-subtle {
+:root:not(.dark) .border-subtle {
   border-color: #e5e7eb;
 }
 
-:not(.dark) .bg-space-700,
-:not(.dark) .bg-space-800,
-:not(.dark) .bg-space-900 {
+:root:not(.dark) .bg-space-700,
+:root:not(.dark) .bg-space-800,
+:root:not(.dark) .bg-space-900 {
   background-color: #f3f4f6;
 }
 
-:not(.dark) .bg-card-hover {
+:root:not(.dark) .bg-card-hover {
   background-color: #f9fafb;
 }


### PR DESCRIPTION
## Problem
Stat cards and other `.glass-card` / `.bg-card` elements were showing light backgrounds even in dark mode (see screenshot in #sat-tracker).

## Root Cause
CSS selectors like `:not(.dark) .glass-card` match any ancestor without `.dark` — including `<body>`. Since only `<html>` gets the `.dark` class, the light mode override always won.

## Fix
Changed all `:not(.dark)` selectors to `:root:not(.dark)` so they only match when the root `<html>` element lacks the `.dark` class.

## Testing
- Dark mode: cards now use dark glassmorphism backgrounds
- Light mode: cards still use white/light backgrounds
- Theme toggle transitions smoothly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined light mode styling for improved visual consistency. Updated styling across card components, borders, and background elements to ensure proper color application and uniform appearance throughout the interface when light mode is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->