### PR TITLE
fix: idempotent migrations

### DIFF
--- a/backend/alembic/versions/i50_job_name.py
+++ b/backend/alembic/versions/i50_job_name.py
@@ -15,20 +15,18 @@ depends_on = None
 
 
 def upgrade():
-    # Use try/except to handle race condition when multiple containers
-    # (api + worker) run alembic upgrade head simultaneously
-    try:
-        conn = op.get_bind()
-        result = conn.execute(
-            sa.text(
-                "SELECT 1 FROM information_schema.columns "
-                "WHERE table_name='jobs' AND column_name='name'"
-            )
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name='jobs' AND column_name='name'"
         )
-        if not result.fetchone():
+    )
+    if not result.fetchone():
+        try:
             op.add_column("jobs", sa.Column("name", sa.String(255), nullable=True))
-    except sa.exc.ProgrammingError:
-        pass
+        except (sa.exc.ProgrammingError, sa.exc.OperationalError):
+            pass
 
 
 def downgrade():

--- a/backend/alembic/versions/j60_composites.py
+++ b/backend/alembic/versions/j60_composites.py
@@ -14,6 +14,15 @@ depends_on = None
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_name='composites'"
+        )
+    )
+    if result.fetchone():
+        return
     op.create_table(
         "composites",
         sa.Column("id", sa.String(36), primary_key=True),


### PR DESCRIPTION
Migrations now check if column/table exists before ALTER/CREATE to handle create_all() race

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database migration robustness with enhanced error handling and safeguards against duplicate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->