### PR TITLE
fix: register animation task, fix WS auth, fix data dir permissions

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,7 +36,8 @@ COPY backend/alembic /app/alembic
 COPY backend/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
-RUN adduser --disabled-password --gecos '' appuser && chown -R appuser /app
+RUN mkdir -p /app/data/output /app/data/uploads /app/data/temp && \
+    adduser --disabled-password --gecos '' appuser && chown -R appuser /app
 USER appuser
 
 EXPOSE 8000

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -13,7 +13,7 @@ celery_app = Celery(
     "satellite_processor",
     broker=settings.celery_broker_url,
     backend=settings.celery_result_backend,
-    include=["app.tasks.processing", "app.tasks.goes_tasks", "app.tasks.scheduling_tasks"],
+    include=["app.tasks.processing", "app.tasks.goes_tasks", "app.tasks.scheduling_tasks", "app.tasks.animation_tasks"],
 )
 
 celery_app.conf.update(

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Ensure data directories exist and are writable
+mkdir -p /app/data/output /app/data/uploads /app/data/temp 2>/dev/null || true
+
 # Run database migrations with retry (handles race condition when
 # multiple containers run alembic upgrade head simultaneously)
 MAX_RETRIES=3

--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -1,0 +1,13 @@
+/**
+ * Build a WebSocket URL with optional API key authentication.
+ */
+export function buildWsUrl(path: string): string {
+  const protocol = globalThis.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const base = `${protocol}//${globalThis.location.host}${path}`;
+  const apiKey = import.meta.env.VITE_API_KEY;
+  if (apiKey) {
+    const sep = path.includes('?') ? '&' : '?';
+    return `${base}${sep}api_key=${encodeURIComponent(apiKey)}`;
+  }
+  return base;
+}

--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react';
+import { buildWsUrl } from '../api/ws';
 
 type Status = 'connected' | 'reconnecting' | 'disconnected';
 
@@ -31,9 +32,8 @@ function connect() {
     setStatus('disconnected');
     return;
   }
-  const protocol = globalThis.location.protocol === 'https:' ? 'wss:' : 'ws:';
   try {
-    ws = new WebSocket(`${protocol}//${globalThis.location.host}/ws/status`);
+    ws = new WebSocket(buildWsUrl('/ws/status'));
     ws.onopen = () => setStatus('connected');
     ws.onclose = () => {
       ws = null;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { buildWsUrl } from '../api/ws';
 
 interface JobProgress {
   progress: number;
@@ -38,8 +39,7 @@ export function useWebSocket(jobId: string | null, maxRetries = DEFAULT_MAX_RETR
   const connect = useCallback(() => {
     if (!jobId || terminalRef.current) return;
 
-    const protocol = globalThis.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const ws = new WebSocket(`${protocol}//${globalThis.location.host}/ws/jobs/${jobId}`);
+    const ws = new WebSocket(buildWsUrl(`/ws/jobs/${jobId}`));
     wsRef.current = ws;
 
     ws.onopen = () => {


### PR DESCRIPTION
## Fixes

### 1. Animation task not registered in Celery worker
The `generate_animation` task was defined but not included in the Celery app's `include` list, causing animations to stay stuck at 'pending' forever.

### 2. WebSocket connections failing with 403
Frontend WebSocket connections didn't pass the API key. Added `buildWsUrl()` helper that appends `?api_key=` to WS URLs when `VITE_API_KEY` is configured.

### 3. Permission denied on data directories
The `/app/data` volume was root-owned, preventing `appuser` from creating output directories. Fixed by pre-creating subdirs in Dockerfile and entrypoint.