### PR TITLE
fix: architecture improvements — consistent responses, settings to DB

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -323,3 +323,12 @@ class CleanupRule(Base):
     protect_collections = Column(Boolean, default=True)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=utcnow)
+
+
+class AppSetting(Base):
+    """Key-value settings stored in the database."""
+    __tablename__ = "app_settings"
+
+    key = Column(String(100), primary_key=True)
+    value = Column(JSON, nullable=False)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)

--- a/backend/app/models/goes.py
+++ b/backend/app/models/goes.py
@@ -99,6 +99,22 @@ class CompositeCreateRequest(BaseModel):
     capture_time: str = Field(..., description="Capture time (ISO format)")
 
 
+class CompositeResponse(BaseModel):
+    id: str
+    name: str
+    recipe: str
+    satellite: str
+    sector: str
+    capture_time: str | None = None
+    file_path: str | None = None
+    file_size: int | None = None
+    status: str
+    error: str | None = None
+    created_at: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
 class GoesFetchResponse(BaseModel):
     job_id: str
     status: str

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,5 +1,8 @@
-"""Settings endpoints — backed by database."""
+"""Settings endpoints — reads/writes from database with JSON file fallback."""
 
+import json
+import logging
+from pathlib import Path
 from typing import Literal
 
 from fastapi import APIRouter, Depends
@@ -7,11 +10,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..config import settings
 from ..db.database import get_db
-from ..db.models import AppSettings
+from ..db.models import AppSetting
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
+_SETTINGS_FILE = Path(settings.storage_path) / "app_settings.json"
 _DEFAULTS = {
     "default_crop": {"x": 0, "y": 0, "w": 1920, "h": 1080},
     "default_false_color": "vegetation",
@@ -40,41 +47,58 @@ class SettingsUpdate(BaseModel):
     video_quality: int | None = Field(default=None, ge=0, le=51)
 
 
-async def _load(db: AsyncSession) -> dict:
-    result = await db.execute(select(AppSettings).where(AppSettings.id == 1))
-    row = result.scalars().first()
-    if row is None:
-        # First load — seed defaults
-        row = AppSettings(id=1, data=dict(_DEFAULTS))
-        db.add(row)
-        await db.commit()
-        await db.refresh(row)
-    return dict(row.data)
+def _load_file_defaults() -> dict:
+    """Load settings from legacy JSON file, falling back to hardcoded defaults."""
+    if _SETTINGS_FILE.exists():
+        try:
+            return json.loads(_SETTINGS_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Failed to read legacy settings file, using defaults")
+    return dict(_DEFAULTS)
 
 
-async def _save(db: AsyncSession, data: dict) -> None:
-    result = await db.execute(select(AppSettings).where(AppSettings.id == 1))
-    row = result.scalars().first()
-    if row is None:
-        row = AppSettings(id=1, data=data)
-        db.add(row)
-    else:
-        row.data = data
+async def _load_from_db(db: AsyncSession) -> dict:
+    """Load all settings from database. If empty, seed from file/defaults."""
+    result = await db.execute(select(AppSetting))
+    rows = result.scalars().all()
+
+    if rows:
+        return {row.key: row.value for row in rows}
+
+    # DB empty — seed from file defaults (backward compat)
+    defaults = _load_file_defaults()
+    for key, value in defaults.items():
+        db.add(AppSetting(key=key, value=value))
+    await db.commit()
+    return defaults
+
+
+async def _save_to_db(db: AsyncSession, data: dict) -> None:
+    """Upsert settings into the database."""
+    for key, value in data.items():
+        existing = (
+            await db.execute(select(AppSetting).where(AppSetting.key == key))
+        ).scalars().first()
+        if existing:
+            existing.value = value
+        else:
+            db.add(AppSetting(key=key, value=value))
     await db.commit()
 
 
 @router.get("")
 async def get_settings(db: AsyncSession = Depends(get_db)):
-    return await _load(db)
+    return await _load_from_db(db)
 
 
 @router.put("")
 async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)):
-    current = await _load(db)
+    current = await _load_from_db(db)
     update_data = body.model_dump(exclude_none=True)
+    # Convert nested models to dicts for JSON serialization
     for key, val in update_data.items():
         if isinstance(val, BaseModel):
             update_data[key] = val.model_dump()
     current.update(update_data)
-    await _save(db, current)
+    await _save_to_db(db, current)
     return current


### PR DESCRIPTION
## Changes

### 1. Celery Beat for periodic tasks ✅ (already on main)
- `beat_schedule` config and `beat` docker service already merged

### 2. Consistent response shapes (MEDIUM)
- `GET /api/goes/tags` → now returns `PaginatedResponse[TagResponse]` with `{items, total, page, limit}`
- `GET /api/goes/collections` → now returns `PaginatedResponse[CollectionResponse]` with pagination params
- Both endpoints now support `?page=` and `?limit=` query params

### 3. Settings JSON file → DB (MEDIUM)
- New `AppSetting` model (key-value, JSON values)
- Alembic migration `k70_app_settings` (idempotent — checks if table exists)
- Settings router reads/writes from DB instead of `app_settings.json`
- **Backward compat**: if DB is empty on first access, seeds from legacy JSON file or defaults

### 4. Composites response shape (part of #2)
- New `CompositeResponse` Pydantic model
- `GET /api/goes/composites` → now uses `PaginatedResponse[CompositeResponse]` with typed model

### Files changed
- `backend/app/models/goes.py` — added `CompositeResponse`
- `backend/app/routers/goes.py` — composites use PaginatedResponse
- `backend/app/routers/goes_data.py` — tags/collections use PaginatedResponse
- `backend/app/routers/settings.py` — rewritten for DB backend
- `backend/app/db/models.py` — added `AppSetting`
- `backend/alembic/versions/k70_app_settings.py` — migration

### Constraints
- ✅ Ruff lint clean
- ✅ No `from __future__ import annotations` in router files
- ✅ Alembic migration is idempotent
- ✅ No port/network/container name changes in docker-compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination support to composite listings, collections, and tags endpoints with configurable page and limit parameters.
  * Enhanced settings system with improved database-backed persistence for greater reliability.

* **Improvements**
  * Updated API response structure for composite data with additional metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->