### PR TITLE
fix: add missing tasks/helpers module causing fetch tab error

### DIFF
--- a/backend/app/tasks/helpers.py
+++ b/backend/app/tasks/helpers.py
@@ -1,0 +1,8 @@
+"""Helper utilities for background tasks.
+
+Re-exports common functions from processing module for convenient imports.
+"""
+
+from .processing import _get_redis, _get_sync_db, _publish_progress, _update_job_db
+
+__all__ = ["_get_redis", "_get_sync_db", "_publish_progress", "_update_job_db"]


### PR DESCRIPTION
The animation overhaul moved helper functions to processing.py but three task files still import from .helpers. Creates helpers.py as a re-export module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization improvements to backend utilities for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->