### PR TITLE
Fix Dashboard dark mode styling

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -88,7 +88,7 @@ export default function Dashboard() {
       {statsLoading && !statsError && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {["a","b","c","d"].map((k) => (
-            <div key={k} className="bg-gray-200/50 dark:bg-white/[0.06] border border-subtle rounded-xl p-4 h-24 animate-pulse" />
+            <div key={k} className="bg-gray-200/50 dark:bg-white/[0.06] border border-gray-200 dark:border-space-700/50 rounded-xl p-4 h-24 animate-pulse" />
           ))}
         </div>
       )}
@@ -96,7 +96,7 @@ export default function Dashboard() {
         {statCards.map((s) => (
           <div
             key={s.label}
-            className="bg-white/75 dark:bg-space-800/70 backdrop-blur-sm border border-subtle rounded-xl p-4 hover:bg-gray-50 dark:hover:bg-space-700 transition-colors inset-shadow-sm dark:inset-shadow-white/5"
+            className="bg-white/75 dark:bg-space-800/70 backdrop-blur-sm border border-gray-200 dark:border-space-700/50 rounded-xl p-4 hover:bg-gray-50 dark:hover:bg-space-700 transition-colors inset-shadow-sm dark:inset-shadow-white/5"
           >
             <div className="flex items-center justify-between">
               <s.icon className={`w-5 h-5 ${s.color}`} />
@@ -107,7 +107,7 @@ export default function Dashboard() {
         ))}
 
         {/* Storage card */}
-        <div className="bg-white/75 dark:bg-space-800/70 backdrop-blur-sm border border-subtle rounded-xl p-4 hover:bg-gray-50 dark:hover:bg-space-700 transition-colors inset-shadow-sm dark:inset-shadow-white/5">
+        <div className="bg-white/75 dark:bg-space-800/70 backdrop-blur-sm border border-gray-200 dark:border-space-700/50 rounded-xl p-4 hover:bg-gray-50 dark:hover:bg-space-700 transition-colors inset-shadow-sm dark:inset-shadow-white/5">
           <div className="flex items-center justify-between">
             <HardDrive className="w-5 h-5 text-emerald-400" />
             <span className="text-xs text-gray-400 dark:text-slate-500">{storagePercent}%</span>
@@ -126,7 +126,7 @@ export default function Dashboard() {
 
       {/* GOES stats error fallback */}
       {goesError && (
-        <div className="bg-white dark:bg-space-800 border border-subtle rounded-xl p-6 text-center">
+        <div className="bg-white dark:bg-space-800 border border-gray-200 dark:border-space-700/50 rounded-xl p-6 text-center">
           <Satellite className="w-8 h-8 text-gray-400 dark:text-slate-500 mx-auto mb-2" />
           <p className="text-sm text-gray-500 dark:text-slate-400">Could not load satellite data</p>
         </div>
@@ -134,7 +134,7 @@ export default function Dashboard() {
 
       {/* GOES stats loading skeleton (#9) */}
       {goesLoading && !goesError && (
-        <div className="bg-gray-200/50 dark:bg-white/[0.06] border border-subtle rounded-xl p-6 space-y-4 animate-pulse">
+        <div className="bg-gray-200/50 dark:bg-white/[0.06] border border-gray-200 dark:border-space-700/50 rounded-xl p-6 space-y-4 animate-pulse">
           <div className="flex items-center gap-2">
             <div className="w-5 h-5 rounded bg-gray-200 dark:bg-white/10" />
             <div className="h-5 w-32 rounded bg-gray-200 dark:bg-white/10" />
@@ -149,7 +149,7 @@ export default function Dashboard() {
 
       {/* GOES stats empty state (API returned but no data) */}
       {!goesLoading && goesStats && totalGoesFrames === 0 && !showOnboarding && (
-        <div className="bg-card border border-subtle rounded-xl p-6 text-center">
+        <div className="bg-white dark:bg-space-800/70 border border-gray-200 dark:border-space-700/50 rounded-xl p-6 text-center">
           <Satellite className="w-8 h-8 text-gray-400 dark:text-slate-500 mx-auto mb-2" />
           <p className="text-sm text-gray-500 dark:text-slate-400">No satellite data yet</p>
           <p className="text-xs text-gray-400 dark:text-slate-500 mt-1">Fetch GOES data to see stats here</p>
@@ -158,7 +158,7 @@ export default function Dashboard() {
 
       {/* #1: Satellite Data Section */}
       {goesStats && totalGoesFrames > 0 && (
-        <div className="bg-card border border-subtle rounded-xl p-6 space-y-4">
+        <div className="bg-white dark:bg-space-800/70 border border-gray-200 dark:border-space-700/50 rounded-xl p-6 space-y-4">
           <div className="flex items-center gap-2">
             <Satellite className="w-5 h-5 text-primary" />
             <h2 className="text-lg font-semibold">Satellite Data</h2>
@@ -247,7 +247,7 @@ export default function Dashboard() {
 
       {/* #4: Empty State Onboarding */}
       {showOnboarding && (
-        <div className="bg-card border border-primary/20 rounded-xl p-6">
+        <div className="bg-white dark:bg-space-800/70 border border-primary/20 rounded-xl p-6">
           <div className="flex items-center gap-2 mb-4">
             <Rocket className="w-5 h-5 text-primary" />
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Get Started</h2>
@@ -304,7 +304,7 @@ export default function Dashboard() {
 
       {/* Getting Started - original (shown when no images but has GOES frames) */}
       {stats?.total_images === 0 && totalGoesFrames > 0 && (
-        <div className="bg-card border border-primary/20 rounded-xl p-6">
+        <div className="bg-white dark:bg-space-800/70 border border-primary/20 rounded-xl p-6">
           <div className="flex items-center gap-2 mb-4">
             <Rocket className="w-5 h-5 text-primary" />
             <h2 className="text-lg font-semibold">Getting Started with Processing</h2>
@@ -351,7 +351,7 @@ export default function Dashboard() {
         </button>
         <button
           onClick={() => navigate('/process')}
-          className="flex items-center gap-2 px-5 py-2.5 min-h-11 bg-space-700 hover:bg-space-600 border border-subtle rounded-xl text-sm font-medium transition-colors focus-ring active:scale-[0.97]"
+          className="flex items-center gap-2 px-5 py-2.5 min-h-11 bg-space-700 hover:bg-space-600 border border-gray-200 dark:border-space-700/50 rounded-xl text-sm font-medium transition-colors focus-ring active:scale-[0.97]"
         >
           <FlaskConical className="w-4 h-4" /> New Job
         </button>
@@ -367,10 +367,10 @@ export default function Dashboard() {
         {/* System Health */}
         <div>
           <h2 className="text-lg font-semibold mb-3 flex items-center gap-2"><Activity className="w-5 h-5 text-primary" />System Health</h2>
-          <div className="bg-card border border-subtle rounded-xl p-4 space-y-3 inset-shadow-sm dark:inset-shadow-white/5">
+          <div className="bg-white dark:bg-space-800/70 border border-gray-200 dark:border-space-700/50 rounded-xl p-4 space-y-3 inset-shadow-sm dark:inset-shadow-white/5">
             {/* Overall status */}
             {health && (
-              <div className="flex items-center gap-2 pb-3 border-b border-subtle">
+              <div className="flex items-center gap-2 pb-3 border-b border-gray-200 dark:border-space-700/50">
                 {(() => {
                   const cfg = statusIcon[health.status] ?? statusIcon.ok;
                   const Icon = cfg.icon;


### PR DESCRIPTION
Replaces all abstract CSS classes (`bg-card`, `border-subtle`) in Dashboard.tsx with explicit dark-mode-compatible Tailwind classes.

### Changes
- `bg-card` → `bg-white dark:bg-space-800/70` (fixes white backgrounds in dark mode)
- `border-subtle` → `border-gray-200 dark:border-space-700/50` (fixes prominent teal borders)

### Affected sections
- Satellite Data card container
- GOES stats empty state
- Onboarding/Getting Started cards
- System Health panel
- Quick action buttons
- Skeleton loading states

All 38 test files (169 tests) pass. No lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Enhanced visual styling across the dashboard with improved light and dark mode theme consistency, affecting cards, statistics displays, storage information, and section headers for a more refined and cohesive appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->