### PR TITLE
fix: resolve remaining SonarQube leftovers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -260,7 +260,7 @@ async def _ws_ping(websocket: WebSocket) -> None:
         while True:
             await asyncio.sleep(WS_PING_INTERVAL)
             await websocket.send_json({"type": "ping"})
-    except Exception:
+    except WebSocketDisconnect:
         pass
 
 
@@ -362,5 +362,5 @@ async def status_websocket(websocket: WebSocket):
         while True:
             await asyncio.sleep(WS_PING_INTERVAL)
             await websocket.send_json({"type": "ping"})
-    except Exception:
+    except WebSocketDisconnect:
         pass

--- a/backend/app/routers/goes.py
+++ b/backend/app/routers/goes.py
@@ -47,7 +47,7 @@ async def list_products():
 
     products = {
         "satellites": list(SATELLITE_BUCKETS),
-        "satellite_availability": {**SATELLITE_AVAILABILITY},
+        "satellite_availability": dict(SATELLITE_AVAILABILITY),
         "sectors": [
             {"id": k, "name": k, "product": v}
             for k, v in SECTOR_PRODUCTS.items()

--- a/frontend/src/components/GoesData/PresetsTab.tsx
+++ b/frontend/src/components/GoesData/PresetsTab.tsx
@@ -221,14 +221,14 @@ export default function PresetsTab() {
   );
 }
 
-function PresetForm({ form, setForm, onSubmit, onCancel, loading, title }: {
+function PresetForm({ form, setForm, onSubmit, onCancel, loading, title }: Readonly<{
   form: { name: string; satellite: string; sector: string; band: string; description: string };
   setForm: React.Dispatch<React.SetStateAction<typeof form>>;
   onSubmit: () => void;
   onCancel: () => void;
   loading: boolean;
   title: string;
-}) {
+}>) {
   return (
     <div className="mb-4 bg-gray-100 dark:bg-slate-800 rounded-lg p-4 space-y-3">
       <h3 className="text-sm font-medium text-gray-600 dark:text-slate-300">{title}</h3>

--- a/frontend/src/components/GoesData/utils.ts
+++ b/frontend/src/components/GoesData/utils.ts
@@ -3,5 +3,5 @@ export function formatBytes(bytes: number): string {
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+  return Number.parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,19 +33,18 @@
 html {
   transition: background-color 0.3s ease, color 0.3s ease;
   font-size: 14px;
+
+  @media (min-width: 640px) {
+    font-size: 15px;
+  }
+  @media (min-width: 1024px) {
+    font-size: 16px;
+  }
 }
 
 body {
   @apply bg-gray-50 dark:bg-space-950 text-gray-900 dark:text-gray-100 antialiased;
   transition: background-color 0.3s ease, color 0.3s ease;
-}
-
-/* Responsive typography — smaller on mobile, larger on desktop */
-@media (min-width: 640px) {
-  html { font-size: 15px; }
-}
-@media (min-width: 1024px) {
-  html { font-size: 16px; }
 }
 
 /* Touch-friendly button targets on mobile (WCAG 2.5.5 — 44px minimum) */

--- a/satellite_processor/core/image_operations.py
+++ b/satellite_processor/core/image_operations.py
@@ -50,7 +50,6 @@ class ImageOperations:
         method: str = "Standard",
     ) -> bool:
         """Apply false color using Sanchez"""
-        temp_dir = None
         try:
             # Verify input files
             sanchez_exe = Path(sanchez_path)
@@ -114,10 +113,6 @@ class ImageOperations:
         except Exception as e:
             logger.error(f"Error in apply_false_color: {e}", exc_info=True)
             return False
-
-        finally:
-            # temp_dir is reserved for future use when Sanchez needs staging
-            pass
 
     @staticmethod
     def add_timestamp(


### PR DESCRIPTION
Resolve 6 remaining SonarQube code-smell findings:

- **backend/main.py**: Narrow bare `except Exception` to `except WebSocketDisconnect` in WS ping loops (2 occurrences)
- **backend/routers/goes.py**: Use `dict()` instead of `{**...}` spread for clarity
- **frontend/PresetsTab.tsx**: Add `Readonly<>` to PresetForm props
- **frontend/utils.ts**: `parseFloat` → `Number.parseFloat` (SonarQube preference)
- **frontend/index.css**: Nest responsive font-size media queries inside `html` block (merge duplicate selectors)
- **satellite_processor/image_operations.py**: Remove unused `temp_dir` variable and empty `finally` block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved error handling specificity in WebSocket operations
  * Enhanced type safety in component properties
  * Code cleanup and reorganization for maintainability
  
* **Chores**
  * Removed unused code to reduce technical debt
  * Optimized stylesheet structure with no visual changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->