### PR TITLE
fix: add /api/download endpoint — all images broken

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from .redis_pool import close_redis_pool, get_redis_client
 from .routers import (
     animations,
     download,
+    file_download,
     goes,
     goes_data,
     health,
@@ -160,6 +161,7 @@ app.include_router(download.router)
 app.include_router(scheduling.router)
 app.include_router(notifications.router)
 app.include_router(share.router)
+app.include_router(file_download.router)
 
 
 # ── Metrics endpoint ──────────────────────────────────────────────

--- a/backend/app/routers/file_download.py
+++ b/backend/app/routers/file_download.py
@@ -1,0 +1,56 @@
+"""Generic file download endpoint for serving data files (images, thumbnails, etc.)."""
+
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import FileResponse
+
+from ..config import settings
+from ..errors import APIError, validate_safe_path
+from ..rate_limit import limiter
+
+router = APIRouter(prefix="/api", tags=["files"])
+
+
+@router.get("/download")
+@limiter.limit("120/minute")
+async def download_file(
+    request: Request,
+    path: str = Query(..., description="Absolute path to the file inside the data directory"),
+) -> FileResponse:
+    """Serve a file from the data directory.
+
+    The path must resolve to a location within the configured storage path.
+    Path traversal attempts are rejected.
+    """
+    if not path:
+        raise APIError(400, "bad_request", "path parameter is required")
+
+    # Validate path stays within storage root
+    storage_root = settings.storage_path
+    resolved = validate_safe_path(path, storage_root)
+
+    if not resolved.exists():
+        raise APIError(404, "not_found", "File not found")
+
+    if not resolved.is_file():
+        raise APIError(400, "bad_request", "Path is not a file")
+
+    # Determine media type from extension
+    suffix = resolved.suffix.lower()
+    media_types = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".mp4": "video/mp4",
+        ".json": "application/json",
+        ".csv": "text/csv",
+    }
+    media_type = media_types.get(suffix, "application/octet-stream")
+
+    return FileResponse(
+        path=str(resolved),
+        media_type=media_type,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )


### PR DESCRIPTION
## Critical Bug Fix

Every image in the app is broken — Live tab, Browse, Gallery, Map, Composites, Animations all show alt text instead of images.

**Root cause:** The frontend uses `/api/download?path=...` across 12 places in 8 components to serve frame images, thumbnails, and animation outputs. This endpoint didn't exist in the backend.

**Fix:** Added `/api/download` endpoint in `file_download.py` that:
- Serves files from the data directory via `FileResponse`
- Uses `validate_safe_path()` to prevent path traversal
- Auto-detects media type from extension
- Rate limited to 120/min
- Sets `Cache-Control: public, max-age=86400`

Nginx already injects the API key for all `/api/` requests, so `<img src>` tags work without client-side auth headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new file download API endpoint (`/api/download`) to serve files from storage.
  * Implemented rate limiting (120 requests per minute) on downloads.
  * Automatic media type detection for downloaded files with proper caching headers.
  * Added path validation to ensure secure file access within the storage directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->