### PR TITLE
design: Deep Space color scheme + visual hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ frontend/test-results/
 frontend/playwright-report/
 frontend/playwright-report/
 frontend/coverage/
+node_modules/

--- a/frontend/src/components/GoesData/AnimationPlayer.tsx
+++ b/frontend/src/components/GoesData/AnimationPlayer.tsx
@@ -225,7 +225,7 @@ export default function AnimationPlayer({ frames, onClose }: Readonly<AnimationP
 
           <button type="button"
             onClick={togglePlay}
-            className="p-3 bg-cyan-600 hover:bg-cyan-500 text-white rounded-full min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="p-3 bg-sky-600 hover:bg-sky-500 text-white rounded-full min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label={playing ? 'Pause' : 'Play'}
           >
             {playing ? <Pause className="w-6 h-6" /> : <Play className="w-6 h-6 ml-0.5" />}
@@ -247,7 +247,7 @@ export default function AnimationPlayer({ frames, onClose }: Readonly<AnimationP
                 onClick={() => setSpeed(s)}
                 className={`px-2 py-1 text-xs rounded min-h-[44px] min-w-[44px] flex items-center justify-center ${
                   speed === s
-                    ? 'bg-cyan-600 text-white'
+                    ? 'bg-sky-600 text-white'
                     : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
                 }`}
                 aria-label={`Speed ${s}x`}
@@ -262,7 +262,7 @@ export default function AnimationPlayer({ frames, onClose }: Readonly<AnimationP
             onClick={() => setLoop((l) => !l)}
             className={`p-2 rounded-lg min-h-[44px] min-w-[44px] flex items-center justify-center ${
               loop
-                ? 'text-cyan-400 bg-cyan-900/30'
+                ? 'text-sky-400 bg-sky-900/30'
                 : 'text-slate-400 hover:text-white hover:bg-slate-700'
             }`}
             aria-label={loop ? 'Disable loop' : 'Enable loop'}

--- a/frontend/src/components/GoesData/OverviewTab.tsx
+++ b/frontend/src/components/GoesData/OverviewTab.tsx
@@ -119,7 +119,7 @@ export default function OverviewTab() {
       label: 'Fetch Last Hour CONUS',
       description: 'Pre-fill fetch wizard for CONUS imagery',
       icon: <Download className="w-5 h-5" />,
-      color: 'from-cyan-500/20 to-blue-500/20 border-cyan-500/30',
+      color: 'from-sky-500/20 to-blue-500/20 border-sky-500/30',
       onClick: () => {
         globalThis.dispatchEvent(new CustomEvent('fetch-prefill', {
           detail: { satellite: 'GOES-19', sector: 'CONUS', band: 'C02', hours_back: 1 },

--- a/frontend/src/components/System/SystemMonitor.tsx
+++ b/frontend/src/components/System/SystemMonitor.tsx
@@ -10,7 +10,7 @@ export default function SystemMonitor() {
       label: 'CPU',
       value: status?.cpu_percent ?? 0,
       icon: Cpu,
-      color: '#06b6d4',
+      color: '#0ea5e9',
     },
     {
       label: 'RAM',

--- a/frontend/src/constants/bands.ts
+++ b/frontend/src/constants/bands.ts
@@ -11,7 +11,7 @@ export const BAND_INFO: Record<string, BandInfo> = {
   C02: { name: "Red", wavelength: "0.64μm", category: "Visible", color: "#ef4444", description: "Primary visible band, clouds & surface" },
   C03: { name: "Veggie", wavelength: "0.86μm", category: "Near-IR", color: "#22c55e", description: "Vegetation, burn scars, aerosols" },
   C04: { name: "Cirrus", wavelength: "1.37μm", category: "Near-IR", color: "#a855f7", description: "Cirrus cloud detection" },
-  C05: { name: "Snow/Ice", wavelength: "1.61μm", category: "Near-IR", color: "#06b6d4", description: "Snow/ice discrimination, cloud phase" },
+  C05: { name: "Snow/Ice", wavelength: "1.61μm", category: "Near-IR", color: "#0ea5e9", description: "Snow/ice discrimination, cloud phase" },
   C06: { name: "Cloud Particle", wavelength: "2.24μm", category: "Near-IR", color: "#f97316", description: "Cloud particle size, snow" },
   C07: { name: "Shortwave IR", wavelength: "3.9μm", category: "IR", color: "#dc2626", description: "Fire detection, fog at night" },
   C08: { name: "Upper Tropo WV", wavelength: "6.2μm", category: "IR", color: "#6366f1", description: "Upper-level water vapor, jets" },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,9 +4,19 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  --color-primary: #06b6d4;
-  --color-primary-dark: #0891b2;
-  --color-primary-light: #22d3ee;
+  /* Deep Space palette — primary: teal-blue, accent: amber/gold */
+  --color-primary: #0ea5e9;
+  --color-primary-dark: #0284c7;
+  --color-primary-light: #38bdf8;
+
+  --color-accent: #f59e0b;
+  --color-accent-dark: #d97706;
+  --color-accent-light: #fbbf24;
+
+  --color-success: #22c55e;
+  --color-success-muted: #16a34a;
+  --color-error: #ef4444;
+  --color-error-muted: #dc2626;
 
   --color-space-500: #2d6094;
   --color-space-600: #254d7a;
@@ -15,12 +25,12 @@
   --color-space-800: #132240;
   --color-space-850: #0f1d32;
   --color-space-900: #0a1628;
-  --color-space-950: #020617;
+  --color-space-950: #060d1b;
 
-  --color-accent-cyan: #22d3ee;
+  --color-accent-cyan: #38bdf8;
   --color-accent-blue: #3b82f6;
   --color-accent-indigo: #6366f1;
-  --color-accent-glow: #06b6d4;
+  --color-accent-glow: #0ea5e9;
 
   --background-color-card: #0f1d32;
   --background-color-card-hover: #132240;
@@ -44,8 +54,14 @@ html {
 }
 
 body {
-  @apply bg-gray-50 dark:bg-space-950 text-gray-900 dark:text-gray-100 antialiased;
+  @apply bg-gray-50 text-gray-900 dark:text-gray-100 antialiased;
   transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Deep Space gradient background (dark mode) */
+.dark body {
+  background: linear-gradient(180deg, #060d1b 0%, #0a1628 100%);
+  background-attachment: fixed;
 }
 
 /* Touch-friendly button targets on mobile (WCAG 2.5.5 — 44px minimum) */
@@ -260,14 +276,39 @@ header {
 
 /* Glassmorphism for stat cards */
 .glass-card {
-  background: color-mix(in srgb, var(--color-space-800) 70%, transparent);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--color-space-800) 65%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid color-mix(in srgb, var(--color-space-600) 40%, transparent);
+  background-image: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-primary) 5%, transparent),
+    transparent 60%
+  );
 }
 
 /* Light mode glass */
 :root:not(.dark) .glass-card {
-  background: color-mix(in srgb, white 75%, transparent);
+  background: color-mix(in srgb, white 80%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid color-mix(in srgb, #94a3b8 25%, transparent);
+  box-shadow: 0 1px 3px color-mix(in srgb, #0ea5e9 8%, transparent);
+}
+
+/* Hero card — more visual weight for live image & stats */
+.glass-card-hero {
+  background: color-mix(in srgb, var(--color-space-800) 65%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 25%, transparent);
+  box-shadow: 0 0 20px 2px color-mix(in srgb, var(--color-primary) 12%, transparent);
+}
+
+:root:not(.dark) .glass-card-hero {
+  background: white;
+  border: 1px solid color-mix(in srgb, #0ea5e9 20%, transparent);
+  box-shadow: 0 2px 12px color-mix(in srgb, #0ea5e9 12%, transparent);
 }
 
 /* Primary button with color-mix hover */
@@ -281,11 +322,24 @@ header {
 
 /* Subtle glow for active/selected elements */
 .glow-primary {
-  box-shadow: 0 0 8px 1px color-mix(in srgb, var(--color-primary) 40%, transparent);
+  box-shadow: 0 0 10px 2px color-mix(in srgb, var(--color-primary) 30%, transparent);
 }
 
 .glow-primary-strong {
-  box-shadow: 0 0 12px 2px color-mix(in srgb, var(--color-primary) 50%, transparent);
+  box-shadow: 0 0 16px 3px color-mix(in srgb, var(--color-primary) 45%, transparent);
+}
+
+/* Accent (amber) glow for CTAs */
+.glow-accent {
+  box-shadow: 0 0 10px 2px color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+
+/* Thumbnail hover effect */
+.thumb-hover {
+  @apply rounded-lg transition-shadow duration-200;
+}
+.thumb-hover:hover {
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 /* Field sizing for auto-sizing inputs */

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -71,7 +71,7 @@ export default function Dashboard() {
   });
 
   const statCards = [
-    { label: 'Total Images', value: stats?.total_images ?? 0, icon: Image, color: 'text-cyan-400' },
+    { label: 'Total Images', value: stats?.total_images ?? 0, icon: Image, color: 'text-sky-400' },
     { label: 'Total Jobs', value: stats?.total_jobs ?? 0, icon: ListTodo, color: 'text-violet-400' },
     { label: 'Active Jobs', value: stats?.active_jobs ?? 0, icon: Activity, color: 'text-amber-400' },
   ];
@@ -253,7 +253,7 @@ export default function Dashboard() {
               {(() => {
                 const entries = Object.entries(goesStats.storage_by_satellite);
                 const maxVal = Math.max(...entries.map(([, v]) => v), 1);
-                const colors = ['bg-cyan-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400'];
+                const colors = ['bg-sky-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400'];
                 return entries.map(([sat, size], i) => (
                   <div key={sat} className="flex items-center gap-3">
                     <span className="text-xs text-gray-500 dark:text-slate-400 w-20 truncate">{sat}</span>

--- a/frontend/src/pages/DashboardCharts.tsx
+++ b/frontend/src/pages/DashboardCharts.tsx
@@ -86,7 +86,7 @@ export default function DashboardCharts({ goesStats, isLoading }: Readonly<Dashb
           {(() => {
             const entries = Object.entries(goesStats.storage_by_satellite);
             const maxVal = Math.max(...entries.map(([, v]) => v), 1);
-            const colors = ['bg-cyan-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400'];
+            const colors = ['bg-sky-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400'];
             return entries.map(([sat, size], i) => (
               <div key={sat} className="flex items-center gap-3">
                 <span className="text-xs text-gray-500 dark:text-slate-400 w-20 truncate">{sat}</span>

--- a/frontend/src/pages/DashboardStats.tsx
+++ b/frontend/src/pages/DashboardStats.tsx
@@ -24,7 +24,7 @@ interface DashboardStatsProps {
 
 export default function DashboardStats({ stats, isLoading }: Readonly<DashboardStatsProps>) {
   const statCards = [
-    { label: 'Total Images', value: stats?.total_images ?? 0, icon: Image, color: 'text-cyan-400' },
+    { label: 'Total Images', value: stats?.total_images ?? 0, icon: Image, color: 'text-sky-400' },
     { label: 'Total Jobs', value: stats?.total_jobs ?? 0, icon: ListTodo, color: 'text-violet-400' },
     { label: 'Active Jobs', value: stats?.active_jobs ?? 0, icon: Activity, color: 'text-amber-400' },
   ];

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -29,7 +29,7 @@ function StorageSection() {
   const satEntries = Object.entries(storage.by_satellite ?? {});
   const bandEntries = Object.entries(storage.by_band ?? {});
   const maxSatSize = Math.max(...satEntries.map(([, v]) => v.size), 1);
-  const colors = ['bg-cyan-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400', 'bg-pink-400'];
+  const colors = ['bg-sky-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400', 'bg-pink-400'];
 
   return (
     <div className="bg-gray-100 dark:bg-slate-800 rounded-xl p-6 space-y-4 inset-shadow-sm dark:inset-shadow-white/5">


### PR DESCRIPTION
## Deep Space Color Scheme & Visual Hierarchy

### Palette Changes
- **Primary:** teal-blue `#0ea5e9` (sky-500) replacing cyan `#06b6d4`
- **Accent:** amber/gold `#f59e0b` for CTAs (new)
- **Background:** deeper navy gradient `#060d1b` → `#0a1628` (fixed)
- **Space-950:** deepened to `#060d1b`
- **Success/error:** muted semantic colors added

### Visual Hierarchy
- `glass-card`: enhanced with gradient borders, subtle primary tint, stronger blur
- `glass-card-hero`: new variant with primary glow for hero cards (live image, stats)
- `glow-accent`: amber glow utility for CTA elements
- `thumb-hover`: rounded corners + shadow on hover for thumbnails

### Light Mode
- Blue-tinted card shadows via `color-mix()`
- Subtle slate borders on glass cards

### Component Updates
- Replaced hardcoded `cyan-*` classes with `sky-*` equivalents
- Updated hex `#06b6d4` references to `#0ea5e9`

### Testing
- 935/936 tests pass (1 pre-existing failure in LayoutDrawer)
- Vite build passes cleanly