### PR TITLE
fix: use self-hosted runner for Portainer deploy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,7 +85,7 @@ jobs:
   deploy:
     name: Deploy to Portainer
     needs: build-and-push
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci]
     if: github.ref == 'refs/heads/release'
 
     steps:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,7 @@
     }],
     ["@semantic-release/git", {
       "assets": ["VERSION", "CHANGELOG.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]"
+      "message": "chore(release): ${nextRelease.version}"
     }],
     "@semantic-release/github"
   ]


### PR DESCRIPTION
## Changes

- **Deploy job runner**: Changed `runs-on` from `ubuntu-latest` to `[self-hosted, ci]` so the deploy job can reach Portainer at its LAN address
- **Release commit message**: Removed `[skip ci]` from semantic-release config so docker workflow triggers on release pushes to the `release` branch
- **GitHub secrets**: Set `PORTAINER_URL`, `PORTAINER_USER`, `PORTAINER_PASSWORD`, and `PORTAINER_STACK_ID`

## Why

GitHub-hosted runners can't reach `http://10.27.27.99:9000` (local network). Self-hosted runners on the same LAN can.

The `[skip ci]` in release commits was preventing the docker build workflow from triggering when releases were pushed to the `release` branch. Semantic-release won't create duplicate releases from `chore(release)` commits, so infinite loops aren't a concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to use self-hosted runners for deployments.
  * Modified release process to automatically trigger CI checks on Git asset commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->