### PR TITLE
fix(ci): holistic SonarQube coverage pipeline fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     name: Lint & Security Audit
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
 
@@ -63,7 +63,7 @@ jobs:
     name: Backend Tests (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +119,7 @@ jobs:
     name: Integration & Migration Tests
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
 
@@ -187,7 +187,7 @@ jobs:
     name: Frontend Tests (Shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +226,7 @@ jobs:
     name: Frontend Build
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
 
@@ -388,27 +388,6 @@ jobs:
           elif [ ! -f coverage.xml ]; then
             echo '<?xml version="1.0" ?><coverage version="6" lines-valid="0" lines-covered="0" line-rate="0" branches-covered="0" branches-valid="0" branch-rate="0" timestamp="0" complexity="0"><sources><source>backend/app</source></sources><packages></packages></coverage>' > coverage.xml
           fi
-
-      - name: Cache backend coverage
-        uses: actions/cache@v4
-        with:
-          path: backend/coverage.xml
-          key: coverage-backend-${{ github.sha }}
-          restore-keys: coverage-backend-
-
-      - name: Cache frontend coverage
-        uses: actions/cache@v4
-        with:
-          path: frontend/coverage/lcov.info
-          key: coverage-frontend-${{ github.sha }}
-          restore-keys: coverage-frontend-
-
-      - name: Cache core coverage
-        uses: actions/cache@v4
-        with:
-          path: core-coverage.xml
-          key: coverage-core-${{ github.sha }}
-          restore-keys: coverage-core-
 
       - name: Ensure coverage files exist (fallback placeholders)
         run: |


### PR DESCRIPTION
## Summary

SonarQube shows 0% coverage because test jobs are skipped on push-to-main (path filters gate them, and push events don't trigger path-filtered jobs reliably).

## Changes

### 1. Always run tests on push-to-main
Added `|| github.event_name == 'push'` to the `if:` conditions on all test jobs (backend, frontend, frontend-build, integration, lint-audit). Path filters still optimize PR runs, but push-to-main always runs everything.

### 2. Remove broken cache carry-forward steps
Removed 3 cache steps from the SonarQube job that attempted to carry forward coverage from previous runs. These don't work (cache keys use `github.sha` which changes every commit) and add unnecessary complexity.

## What this fixes
- Coverage artifacts will always be generated on main branch pushes
- SonarQube will receive real coverage data instead of empty placeholders
- Quality gate can evaluate actual coverage metrics

## What was investigated but NOT changed
- Coverage XML source path mapping: Verified that `<source>backend/app</source>` is correct. pytest-cov generates filenames like `config.py` (root-level) and `routers/goes_data.py` (subdirs), which resolve correctly against the source path.

Closes: supersedes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Extended CI/CD workflow to trigger on push events, expanding test execution beyond pull request workflows
* Removed coverage artifact caching from backend, frontend, and integration pipeline operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->