### PR TITLE
fix: Batch 7 — Raise coverage gates & annotate low-value tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           pytest --splits 4 --group ${{ matrix.shard }} \
             --splitting-algorithm least_duration \
             --cov=app --cov-report=xml:coverage-shard${{ matrix.shard }}.xml \
-            --cov-fail-under=0 -n auto --durations=10 --reruns 1 \
+            --cov-fail-under=60 -n auto --durations=10 --reruns 1 \
             -v --tb=short -q \
             --store-durations \
             tests/
@@ -173,7 +173,7 @@ jobs:
       - name: Run core processor tests
         env:
           PYTHONPATH: ${{ github.workspace }}
-        run: pytest satellite_processor/core/tests/ -v --tb=short --cov --cov-config=pyproject.toml --cov-report=xml:core-coverage.xml --durations=10 --reruns 1 --cov-fail-under=0
+        run: pytest satellite_processor/core/tests/ -v --tb=short --cov --cov-config=pyproject.toml --cov-report=xml:core-coverage.xml --durations=10 --reruns 1 --cov-fail-under=60
 
       - name: Upload core coverage artifact
         if: always()

--- a/frontend/src/test/CoverageBoost.test.tsx
+++ b/frontend/src/test/CoverageBoost.test.tsx
@@ -1,3 +1,6 @@
+// TODO(#43): Low-value coverage boost file. Most tests here render components with
+// fully mocked hooks and only assert text presence. Replace with meaningful integration
+// tests that verify actual user interactions, error handling, and state transitions.
 /**
  * Coverage boost tests — targets low-coverage files to reach 80% overall.
  */

--- a/frontend/src/test/CoverageBoost2.test.tsx
+++ b/frontend/src/test/CoverageBoost2.test.tsx
@@ -1,3 +1,6 @@
+// TODO(#43): Low-value coverage boost file. Hook tests here mostly just check that
+// mutate/data exist without verifying behavior. Replace with tests that exercise
+// actual API interactions, error states, and cache invalidation logic.
 /**
  * Coverage boost tests part 2 — hooks and more components.
  */

--- a/frontend/src/test/CoverageBoost3.test.tsx
+++ b/frontend/src/test/CoverageBoost3.test.tsx
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// TODO(#43): Low-value coverage boost file. Tests mock nearly all dependencies and
+// only verify shallow rendering. Replace with meaningful tests that cover real user
+// workflows through PresetsTab, TagModal, Process, ProcessingForm, etc.
 /**
  * Coverage boost tests for low-coverage components:
  * PresetsTab, TagModal, Process, ProcessingForm, JobList, GoesData, ImageGallery

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
+      thresholds: {
+        lines: 55,
+        functions: 55,
+        branches: 55,
+        statements: 55,
+      },
     },
   },
 })


### PR DESCRIPTION
## Batch 7 — Test Infrastructure

### Changes

**#41 — Coverage gates set to 0%** ✅
- Backend: `--cov-fail-under=0` → `--cov-fail-under=60` (all 4 shards + core processor)
- Frontend: Added coverage thresholds at 55% (lines/functions/branches/statements) in vite.config.ts

**#43 — CoverageBoost test files are low-value** ✅
- Added `TODO(#43)` comments to all 3 CoverageBoost test files identifying them as low-value
- These files mock nearly everything and only test shallow rendering/existence
- Not deleted to avoid impacting coverage gates — should be replaced incrementally

**#42 — E2E tests never run in CI** ⏭️ Skipped
- E2E tests already run in CI (sharded Playwright job exists in test.yml)

### Notes
- Coverage gates are conservative starting points (60% backend, 55% frontend)
- Can ratchet up as test quality improves