### PR TITLE
fix: UX polish — clear filters button, image error placeholder, utility cleanup

### DIFF
--- a/frontend/src/components/GoesData/LazyImage.tsx
+++ b/frontend/src/components/GoesData/LazyImage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { ImageOff } from 'lucide-react';
 import { reportError } from '../../utils/errorReporter';
 
 interface LazyImageProps {
@@ -44,8 +45,9 @@ export default function LazyImage({ src, alt, className, placeholder }: Readonly
   const renderContent = () => {
     if (hasError) {
       return (
-        <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-slate-800 text-gray-400 dark:text-slate-500 text-xs">
-          Failed to load
+        <div className="w-full h-full flex flex-col items-center justify-center gap-2 bg-gray-100 dark:bg-slate-800 text-gray-400 dark:text-slate-500 rounded" data-testid="image-error-placeholder">
+          <ImageOff className="w-8 h-8" aria-hidden="true" />
+          <span className="text-xs font-medium">Image unavailable</span>
         </div>
       );
     }

--- a/frontend/src/test/UxPolish.test.tsx
+++ b/frontend/src/test/UxPolish.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import LazyImage from '../components/GoesData/LazyImage';
+
+// --- LazyImage error placeholder tests ---
+
+type IOCallback = IntersectionObserverCallback;
+
+function setupIO() {
+  let storedCb: IOCallback | null = null;
+  const instances: Array<{ observe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }> = [];
+
+  class MockIO {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    constructor(cb: IOCallback) {
+      storedCb = cb;
+      instances.push(this);
+    }
+  }
+
+  vi.stubGlobal('IntersectionObserver', MockIO);
+
+  function trigger() {
+    const inst = instances[instances.length - 1];
+    if (storedCb && inst) {
+      act(() => {
+        storedCb!([{ isIntersecting: true } as IntersectionObserverEntry], inst as unknown as IntersectionObserver);
+      });
+    }
+  }
+
+  return { trigger, instances };
+}
+
+describe('LazyImage — error placeholder', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('shows ImageOff icon and "Image unavailable" text on error', () => {
+    const io = setupIO();
+    render(<LazyImage src="/broken.jpg" alt="test" />);
+    io.trigger();
+    const img = screen.getByRole('img');
+    fireEvent.error(img);
+
+    const placeholder = screen.getByTestId('image-error-placeholder');
+    expect(placeholder).toBeInTheDocument();
+    expect(screen.getByText('Image unavailable')).toBeInTheDocument();
+    expect(placeholder.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('error placeholder has dark theme classes', () => {
+    const io = setupIO();
+    render(<LazyImage src="/broken.jpg" alt="test" />);
+    io.trigger();
+    fireEvent.error(screen.getByRole('img'));
+
+    const placeholder = screen.getByTestId('image-error-placeholder');
+    expect(placeholder.className).toContain('dark:bg-slate-800');
+    expect(placeholder.className).toContain('dark:text-slate-500');
+  });
+});
+
+// --- BrowseTab clear filters tests ---
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: vi.fn(() => Promise.resolve({ data: {} })),
+    post: vi.fn(() => Promise.resolve({ data: {} })),
+    put: vi.fn(() => Promise.resolve({ data: {} })),
+    delete: vi.fn(() => Promise.resolve({ data: {} })),
+  },
+}));
+
+vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
+vi.mock('../hooks/useDebounce', () => ({ useDebounce: (val: string) => val }));
+
+import BrowseTab from '../components/GoesData/BrowseTab';
+import api from '../api/client';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedApi = api as any;
+
+function renderBrowse() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(<QueryClientProvider client={qc}><BrowseTab /></QueryClientProvider>);
+}
+
+describe('BrowseTab — clear filters button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.get.mockImplementation((url: string) => {
+      if (url.includes('/goes/frames')) return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 50 } });
+      if (url === '/goes/products') return Promise.resolve({ data: { satellites: ['G16', 'G18'], bands: [{ id: 'C01' }], sectors: [{ id: 'CONUS', name: 'CONUS' }] } });
+      if (url === '/goes/tags') return Promise.resolve({ data: [] });
+      if (url === '/goes/collections') return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  it('does not show "Clear all" when no filters active', async () => {
+    renderBrowse();
+    await waitFor(() => expect(screen.queryByText('Clear all')).not.toBeInTheDocument());
+  });
+
+  it('shows "Clear all" when a filter is active and resets on click', async () => {
+    const user = userEvent.setup();
+    renderBrowse();
+
+    // Wait for products to load so selects have options
+    const satSelect = await waitFor(() => {
+      const el = document.getElementById('browse-satellite') as HTMLSelectElement;
+      expect(el).toBeTruthy();
+      return el;
+    });
+
+    // Wait for options to render
+    await waitFor(() => {
+      expect(satSelect.querySelectorAll('option').length).toBeGreaterThan(1);
+    });
+
+    // Set a filter using userEvent
+    await user.selectOptions(satSelect, 'G16');
+
+    const clearBtn = await screen.findByText('Clear all');
+    expect(clearBtn).toBeInTheDocument();
+
+    await user.click(clearBtn);
+
+    // Filter should be reset
+    expect(satSelect.value).toBe('');
+    // Clear all should disappear
+    await waitFor(() => expect(screen.queryByText('Clear all')).not.toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Changes

### Image error placeholder (#14 enhancement)
- **LazyImage.tsx**: Replaced plain "Failed to load" text with a styled placeholder featuring the `ImageOff` icon from lucide-react and "Image unavailable" text
- Matches dark theme styling with proper colors and spacing

### Clear All Filters button (#55)
- Already implemented in BrowseTab — verified it shows "Clear all" when any filter (satellite, band, sector, collection, tag) is active and resets all on click

### Backend utility consolidation
- Checked `backend/app/utils/` — already clean with only `metadata.py` and `path_validation.py`. No consolidation needed.

### Tests
- Added `UxPolish.test.tsx` with 4 tests covering error placeholder rendering and clear filters behavior
- All 1313 tests pass, eslint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the user experience when images fail to load by improving the error placeholder design with a distinctive icon, rounded corners, and contextual messaging for clearer feedback

* **Tests**
  * Added comprehensive test coverage for image loading error state handling, error placeholder rendering, dark theme styling, and browse tab filter clearing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->