### PR TITLE
fix: resolve SonarQube bugs and code smells

### DIFF
--- a/frontend/src/components/GoesData/BrowseTab.tsx
+++ b/frontend/src/components/GoesData/BrowseTab.tsx
@@ -328,11 +328,8 @@ export default function BrowseTab() {
   }, [toggleSelect]);
 
   const selectAll = () => {
-    if (selectedIds.size === frames.length) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(frames.map((f) => f.id)));
-    }
+    const allSelected = selectedIds.size === frames.length;
+    setSelectedIds(allSelected ? new Set() : new Set(frames.map((f) => f.id)));
   };
 
   // #54: Keyboard shortcuts for BrowseTab

--- a/frontend/src/components/GoesData/LiveTab.tsx
+++ b/frontend/src/components/GoesData/LiveTab.tsx
@@ -99,7 +99,7 @@ async function exitFullscreenSafe() {
   try {
     await document.exitFullscreen();
   } catch {
-    (document as unknown as { webkitExitFullscreen?: () => void }).webkitExitFullscreen?.();
+    await (document as unknown as { webkitExitFullscreen?: () => Promise<void> }).webkitExitFullscreen?.();
   }
 }
 
@@ -107,7 +107,7 @@ async function enterFullscreenSafe(el: HTMLElement) {
   try {
     await el.requestFullscreen();
   } catch {
-    (el as unknown as { webkitRequestFullscreen?: () => void }).webkitRequestFullscreen?.();
+    await (el as unknown as { webkitRequestFullscreen?: () => Promise<void> }).webkitRequestFullscreen?.();
   }
 }
 


### PR DESCRIPTION
**Bugs (2 MAJOR):**
- Add await to webkit fullscreen fallbacks in LiveTab.tsx — SonarQube flagged un-awaited promises in try/catch blocks

**Code Smells (1 CRITICAL):**
- Simplify BrowseTab selectAll to reduce cognitive complexity from 16 to 15

Note: Remaining code smells (LiveTab complexity 18, MobileBottomNav listener, goes.py async) are either false positives or require major refactoring that would hurt readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fullscreen mode functionality to properly await asynchronous operations, resolving potential issues with browser API compatibility and ensuring consistent behavior across all supported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->