### PR TITLE
chore(deps): bump upload-artifact v4→v5 and download-artifact v4→v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: backend-coverage-shard${{ matrix.shard }}
           path: backend/coverage-shard${{ matrix.shard }}.xml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload core coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: core-coverage
           path: core-coverage.xml
@@ -282,7 +282,7 @@ jobs:
         run: npx vitest run --coverage --shard=${{ matrix.shard }}/2
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: frontend-coverage-shard${{ matrix.shard }}
           path: frontend/coverage/lcov.info
@@ -312,7 +312,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: frontend-build
           path: frontend/dist/
@@ -348,7 +348,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: frontend-build
           path: frontend/dist/
@@ -372,7 +372,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report-shard${{ matrix.shard }}
           path: frontend/playwright-report/
@@ -380,7 +380,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-traces-shard${{ matrix.shard }}
           path: frontend/test-results/
@@ -407,7 +407,7 @@ jobs:
 
       - name: Download backend coverage shards
         id: dl-backend
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           pattern: backend-coverage-shard*
@@ -419,7 +419,7 @@ jobs:
 
       - name: Download frontend coverage shards
         id: dl-frontend
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           pattern: frontend-coverage-shard*
@@ -435,7 +435,7 @@ jobs:
 
       - name: Download core coverage
         id: dl-core
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: core-coverage
@@ -969,7 +969,7 @@ jobs:
 
       - name: Download backend coverage shards
         if: needs.backend.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           pattern: backend-coverage-*
@@ -978,7 +978,7 @@ jobs:
 
       - name: Download frontend coverage shards
         if: needs.frontend.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           pattern: frontend-coverage-shard*
@@ -1009,7 +1009,7 @@ jobs:
 
       - name: Upload merged coverage
         if: needs.backend.result == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: backend-coverage-merged
           path: backend/coverage.xml


### PR DESCRIPTION
Bumps actions/upload-artifact from v4 to v5 and actions/download-artifact from v4 to v7. These must be upgraded together as v7 download-artifact is incompatible with v4 upload-artifact artifacts.

Also closes #211 (Dependabot download-artifact PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest stable versions for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->