### PR TITLE
fix: Docker build cache staleness for version metadata

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,4 @@
 FROM python:3.11-slim
-ARG BUILD_VERSION=0.0.0
-ARG BUILD_COMMIT=dev
-ARG BUILD_DATE=""
-ARG BUILD_SHA=dev
-ENV BUILD_VERSION=${BUILD_VERSION}
-ENV BUILD_COMMIT=${BUILD_COMMIT}
-ENV BUILD_DATE=${BUILD_DATE}
-ENV BUILD_SHA=${BUILD_SHA}
 
 WORKDIR /app
 
@@ -28,6 +20,16 @@ COPY satellite_processor /app/satellite_processor
 
 # Copy backend app
 COPY backend/app /app/app
+
+# Build metadata — placed AFTER code layers to avoid cache pollution
+ARG BUILD_VERSION=0.0.0
+ARG BUILD_COMMIT=dev
+ARG BUILD_DATE=""
+ARG BUILD_SHA=dev
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV BUILD_COMMIT=${BUILD_COMMIT}
+ENV BUILD_DATE=${BUILD_DATE}
+ENV BUILD_SHA=${BUILD_SHA}
 
 # Copy Alembic migration files
 COPY backend/alembic.ini /app/alembic.ini


### PR DESCRIPTION
Moves ARG/ENV build metadata (BUILD_VERSION, BUILD_COMMIT, BUILD_DATE, BUILD_SHA) after the code COPY layers in the backend Dockerfile.

Previously these were at the top, causing GHA layer cache to serve stale metadata even when the VERSION file changed. Now the heavy layers (apt-get, pip install) are cached properly, and build metadata is always fresh.

Fixes the version reporting being stuck on old values after deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build layer ordering to improve build cache efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->