### PR TITLE
fix: version display field mismatch and stale cache

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -129,6 +129,7 @@ function VersionInfo() {
       return r.data as { version?: string; commit?: string; build_date?: string };
     },
     staleTime: 5 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
   });
 
   const version = data?.version ?? '';


### PR DESCRIPTION
## Changes

- **Fixed field name mismatch:** Changed `commit_sha` to `commit` in the VersionInfo component to match the actual API response from `/health/version`
- **Added build date display:** Shows `build_date` from the API in the About section when available
- **Fixed stale cache:** Changed `staleTime` from `Infinity` to 5 minutes so version info refreshes periodically

## Context
The API returns `{ version, commit, build_date, build }` but the frontend was looking for `commit_sha`, causing the commit SHA to never display. The `Layout.tsx` component already used the correct field name (`commit`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build date is now shown in version details when available.
  * Short commit SHA display updated to reflect the latest version data.

* **Improvements**
  * Version information now refreshes every 5 minutes for more current data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->