### PR TITLE
fix: Live View UX friction — picker, gestures, overlay timing

### DIFF
--- a/frontend/src/components/GoesData/SwipeHint.tsx
+++ b/frontend/src/components/GoesData/SwipeHint.tsx
@@ -3,11 +3,17 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const STORAGE_KEY = 'liveSwipeHintSeen';
 
+interface SwipeHintProps {
+  availableBands?: number;
+  isZoomed?: boolean;
+}
+
 /**
  * Shows left/right chevron arrows on first visit to hint at swipe-to-change-band.
- * Fades out after 2 seconds and sets localStorage so it won't show again.
+ * Fades out after 3.5 seconds and sets localStorage so it won't show again.
+ * Hidden when only 1 band is available or when zoomed in.
  */
-export default function SwipeHint() {
+export default function SwipeHint({ availableBands = 2, isZoomed = false }: Readonly<SwipeHintProps>) {
   // Check localStorage synchronously during init to avoid effect setState
   const [visible, setVisible] = useState(() => {
     try {
@@ -24,11 +30,11 @@ export default function SwipeHint() {
       try {
         localStorage.setItem(STORAGE_KEY, '1');
       } catch { /* ignore */ }
-    }, 2000);
+    }, 3500);
     return () => clearTimeout(timer);
   }, [visible]);
 
-  if (!visible) return null;
+  if (!visible || availableBands <= 1 || isZoomed) return null;
 
   return (
     <>

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -21,7 +21,7 @@ export function usePullToRefresh({
   const touchStartY = useRef<number | null>(null);
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
-    if (!enabled || isRefreshing) return;
+    if (!enabled || isRefreshing) { touchStartY.current = null; return; }
     const el = containerRef.current;
     // Only activate when scrolled to top
     if (el && el.scrollTop <= 0) {

--- a/frontend/src/test/SwipeHint.test.tsx
+++ b/frontend/src/test/SwipeHint.test.tsx
@@ -18,11 +18,11 @@ describe('SwipeHint', () => {
     expect(screen.getByTestId('swipe-hint-right')).toBeInTheDocument();
   });
 
-  it('hides after 2 seconds and sets localStorage', () => {
+  it('hides after 3.5 seconds and sets localStorage', () => {
     render(<SwipeHint />);
     expect(screen.getByTestId('swipe-hint-left')).toBeInTheDocument();
 
-    act(() => { vi.advanceTimersByTime(2100); });
+    act(() => { vi.advanceTimersByTime(3600); });
 
     expect(screen.queryByTestId('swipe-hint-left')).not.toBeInTheDocument();
     expect(localStorage.getItem('liveSwipeHintSeen')).toBe('1');


### PR DESCRIPTION
Fixes 6 high-priority Live Tab UX friction issues:

**#4 Band picker requires 3-4 taps** — PickerRow now accepts `defaultExpanded` prop; Band picker auto-expanded. Added dedicated 'Change Band' button in FAB menu that opens bottom sheet pre-scrolled to bands.

**#6 Swipe-to-change-band conflicts with zoom pan** — `useSwipeBand` handleTouchEnd now accepts `isZoomed` param and returns early when zoomed, preventing band changes during pan gestures.

**#8 Overlay auto-hide too aggressive** — Changed timeout from 3s to 5s.

**#9 Pull-to-refresh conflicts with zoom pan** — `usePullToRefresh` now resets touch tracking when disabled. LiveTab passes `enabled: !zoom.isZoomed`.

**#10 FAB menu disappears on accidental touch** — Added 150ms grace period after menu opens before outside-click listener activates.

**#11 SwipeHint shows when bands can't change** — Now accepts `availableBands` and `isZoomed` props; hidden when ≤1 band or zoomed. Display time increased from 2s to 3.5s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Change Band" option to mobile controls menu for easier band selection.

* **Improvements**
  * Disabled swipe gestures while zoomed to prevent unintended band changes.
  * Extended mobile overlay visibility duration for better content access.
  * Improved band picker accessibility with auto-scroll to view.
  * Enhanced swipe hint display to hide when zoomed or with limited bands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->