### PR TITLE
fix: restore Live View bottom nav + fix band swipe flicker

### DIFF
--- a/frontend/e2e/flow-live-view.spec.ts
+++ b/frontend/e2e/flow-live-view.spec.ts
@@ -219,12 +219,12 @@ test.describe('Live flow', () => {
 
   // --- Responsive ---
 
-  test('mobile viewport — bottom nav hidden on live page', async ({ page }) => {
+  test('mobile viewport — bottom nav visible on live page', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto('/live');
-    // Bottom nav is hidden on /live for full-bleed image experience
+    // Bottom nav is visible on /live with translucent styling
     const bottomNav = page.locator('[data-testid="mobile-bottom-nav"]');
-    await expect(bottomNav).not.toBeVisible({ timeout: 10000 });
+    await expect(bottomNav).toBeVisible({ timeout: 10000 });
   });
 
   test('desktop viewport — sidebar visible', async ({ page }) => {

--- a/frontend/e2e/mobile-live-view.spec.ts
+++ b/frontend/e2e/mobile-live-view.spec.ts
@@ -213,11 +213,11 @@ test.describe('Mobile Live View', () => {
     expect(afterText).toBeTruthy();
   });
 
-  test('bottom nav hidden on live page', async ({ page }) => {
+  test('bottom nav visible on live page', async ({ page }) => {
     await page.goto('/live');
-    // Bottom nav is hidden on /live for full-bleed image experience
+    // Bottom nav is visible on /live with translucent styling
     const bottomNav = page.locator('[data-testid="mobile-bottom-nav"]');
-    await expect(bottomNav).not.toBeVisible({ timeout: 10000 });
+    await expect(bottomNav).toBeVisible({ timeout: 10000 });
   });
 
   test('no page overflow', async ({ page }) => {

--- a/frontend/src/components/GoesData/LiveTab.tsx
+++ b/frontend/src/components/GoesData/LiveTab.tsx
@@ -1116,7 +1116,7 @@ function CdnImage({ src, alt, className, ...props }: Readonly<CdnImageProps>) {
   }
 
   return (
-    <div className="relative w-full h-full flex flex-col items-center justify-center">
+    <div className="relative w-full h-full flex flex-col items-center justify-center bg-slate-900">
       {/* Cached image banner — inline above image, dismissible */}
       {usingCached && cachedMeta && !cachedDismissed && (
         <div className="w-full flex justify-center px-4 py-1" data-testid="cached-image-banner">
@@ -1132,7 +1132,7 @@ function CdnImage({ src, alt, className, ...props }: Readonly<CdnImageProps>) {
       {!loaded && !error && (
         <div className="absolute inset-0 animate-pulse bg-gradient-to-r from-slate-800 via-slate-700 to-slate-800 rounded-lg" data-testid="image-shimmer" />
       )}
-      <div className="relative md:rounded-lg overflow-hidden md:border md:border-white/10 w-full" style={{ aspectRatio: '5/3' }} data-testid="live-image-container">
+      <div className="relative md:rounded-lg overflow-hidden md:border md:border-white/10 w-full bg-slate-900" style={{ aspectRatio: '5/3' }} data-testid="live-image-container">
         {/* Previous image for crossfade */}
         {prevSrc && (
           <img

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -304,7 +304,7 @@ export default function Layout() {
           </div>
         </header>
 
-        <main id="main-content" className={`flex-1 ${isLivePage ? 'max-md:overflow-hidden max-md:p-0 max-md:pb-0 md:overflow-y-auto md:p-8' : 'overflow-y-auto p-4 md:p-8 pb-20 md:pb-8'}`}>
+        <main id="main-content" className={`flex-1 ${isLivePage ? 'max-md:overflow-hidden max-md:p-0 max-md:pb-16 md:overflow-y-auto md:p-8' : 'overflow-y-auto p-4 md:p-8 pb-20 md:pb-8'}`}>
           <ErrorBoundary>
             <Outlet />
           </ErrorBoundary>

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -61,8 +61,7 @@ export default function MobileBottomNav() {
 
   // Close more menu on navigation — handled by NavLink onClick handlers below
 
-  // Hide bottom nav on Live tab for full-bleed image
-  if (location.pathname === '/live') return null;
+  const isLive = location.pathname === '/live';
 
   return (
     <>
@@ -121,7 +120,7 @@ export default function MobileBottomNav() {
       <nav
         data-testid="mobile-bottom-nav"
         aria-label="Mobile navigation"
-        className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-white dark:bg-space-900 border-t border-gray-200 dark:border-space-700/50 safe-bottom"
+        className={`md:hidden fixed bottom-0 left-0 right-0 z-30 safe-bottom ${isLive ? 'bg-black/60 backdrop-blur-md border-t border-white/10' : 'bg-white dark:bg-space-900 border-t border-gray-200 dark:border-space-700/50'}`}
       >
         <div
           role="tablist"

--- a/frontend/src/test/MobileBottomNav.test.tsx
+++ b/frontend/src/test/MobileBottomNav.test.tsx
@@ -32,9 +32,9 @@ describe('MobileBottomNav', () => {
     expect(browseTab).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('hides on /live for full-bleed image', () => {
+  it('shows translucent nav on /live', () => {
     renderWithRouter('/live');
-    expect(screen.queryByTestId('mobile-bottom-nav')).toBeNull();
+    expect(screen.getByTestId('mobile-bottom-nav')).toBeInTheDocument();
   });
 
   it('Animate tab is active on /animate', () => {

--- a/frontend/src/test/MobileBottomNavExtended.test.tsx
+++ b/frontend/src/test/MobileBottomNavExtended.test.tsx
@@ -22,9 +22,9 @@ describe('MobileBottomNav — extended', () => {
     expect(screen.getByRole('tab', { name: 'Browse' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('hides on /live for full-bleed image', () => {
+  it('shows translucent nav on /live', () => {
     renderNav('/live');
-    expect(screen.queryByTestId('mobile-bottom-nav')).toBeNull();
+    expect(screen.getByTestId('mobile-bottom-nav')).toBeInTheDocument();
   });
 
   it('Browse tab active on /goes?tab=browse', () => {


### PR DESCRIPTION
## Changes

### Issue 1: Restore bottom nav on /live page
- PR #241 removed the bottom nav entirely on `/live` with `return null`
- Now keeps nav visible with translucent glass styling: `bg-black/60 backdrop-blur-md border-t border-white/10`
- Restored `pb-16` bottom padding in Layout for mobile live page
- Updated unit tests and E2E tests to expect nav visible

### Issue 2: Fix green flicker on band swipe
- Added `bg-slate-900` background to CdnImage container and wrapper
- Prevents transparent gaps during crossfade showing through to page background
- Dark background matches the image area aesthetic

### Testing
- ✅ ESLint passes (0 errors)
- ✅ TypeScript compiles clean
- ✅ All 1373 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Mobile bottom navigation now visible on the /live page with updated translucent styling.

* **Style**
  * Enhanced dark background styling applied to live content areas.
  * Improved mobile spacing and layout consistency on live pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->