### PR TITLE
fix: prevent CORS credential reflection vulnerability

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Override Cloudflare Access CORS headers to prevent arbitrary origin reflection
+    add_header Access-Control-Allow-Origin "https://sat.neuhard.dev" always;
+    add_header Access-Control-Allow-Credentials "true" always;
+    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+
     # SPA fallback — serve index.html for all routes
     # No-cache on HTML so browsers always fetch the latest entry point
     location / {


### PR DESCRIPTION
## Security Fix

Cloudflare Access/Tunnel reflects arbitrary Origin headers with `Access-Control-Allow-Credentials: true`, allowing any malicious site to make authenticated cross-origin requests.

### Problem
```
curl -I -H 'Origin: https://evil.com' https://sat.neuhard.dev/
→ access-control-allow-origin: https://evil.com
→ access-control-allow-credentials: true
```

### Fix
Add explicit CORS headers at the nginx level with `always` flag to override Cloudflare's reflected headers with the correct allowed origin (`https://sat.neuhard.dev`).

**Note:** If Cloudflare still overrides these at the edge, a Cloudflare Transform Rule will be needed as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cross-origin request handling configuration to establish secure communication pathways between the frontend and backend services. Implemented proper access control headers with credential support to enhance request security and application reliability in accordance with modern standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->