### PR TITLE
fix: pill strip chips open respective picker sections

### DIFF
--- a/frontend/src/components/GoesData/BandPillStrip.tsx
+++ b/frontend/src/components/GoesData/BandPillStrip.tsx
@@ -18,6 +18,7 @@ interface BandPillStripProps {
   satellite: string;
   sector: string;
   onSatelliteClick: () => void;
+  onSectorClick: () => void;
   sectorName?: string;
   satelliteAvailability?: Readonly<Record<string, SatelliteAvailabilityInfo>>;
 }
@@ -29,6 +30,7 @@ export default function BandPillStrip({
   satellite,
   sector,
   onSatelliteClick,
+  onSectorClick,
   sectorName,
   satelliteAvailability,
 }: Readonly<BandPillStripProps>) {
@@ -65,7 +67,7 @@ export default function BandPillStrip({
           {satLabel} ▾
         </button>
         <button
-          onClick={onSatelliteClick}
+          onClick={onSectorClick}
           className="flex items-center gap-1 px-2.5 py-1 rounded-full bg-white/10 border border-white/20 text-white/80 text-xs font-medium hover:bg-white/20 transition-colors"
           data-testid="pill-strip-sector"
         >

--- a/frontend/src/components/GoesData/LiveTab.tsx
+++ b/frontend/src/components/GoesData/LiveTab.tsx
@@ -470,6 +470,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
 
   // Bottom sheet for mobile pickers
   const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
+  const [sheetFocus, setSheetFocus] = useState<'satellite' | 'sector' | 'band' | null>(null);
   const bandPickerRef = useRef<HTMLDivElement>(null);
   const scrollToBandsRef = useRef(false);
 
@@ -737,9 +738,9 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
       </div>
 
       {/* Mobile bottom sheet for pickers */}
-      <BottomSheet open={bottomSheetOpen} onClose={() => setBottomSheetOpen(false)} title="Settings">
+      <BottomSheet open={bottomSheetOpen} onClose={() => { setBottomSheetOpen(false); setSheetFocus(null); }} title="Settings">
         <div className="flex flex-col gap-4">
-          <PickerRow label="Satellite" value={satellite}>
+          <PickerRow label="Satellite" value={satellite} defaultExpanded={sheetFocus === 'satellite'}>
             <div className="flex flex-wrap gap-2 mt-2">
               {(products?.satellites ?? []).map((s) => (
                 <button key={s} onClick={() => { setSatellite(s); }} className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${satellite === s ? 'bg-primary/20 border border-primary/50 text-primary' : 'bg-white/10 border border-white/20 text-white/70 hover:bg-white/20'}`}>
@@ -748,7 +749,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
               ))}
             </div>
           </PickerRow>
-          <PickerRow label="Sector" value={sector}>
+          <PickerRow label="Sector" value={sector} defaultExpanded={sheetFocus === 'sector'}>
             <div className="flex flex-wrap gap-2 mt-2">
               {(products?.sectors ?? []).map((s) => {
                 const unavailable = isSectorUnavailable(s.id, availability?.available_sectors);
@@ -762,7 +763,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
             </div>
           </PickerRow>
           <div ref={bandPickerRef}>
-          <PickerRow label="Band" value={getFriendlyBandName(band)} defaultExpanded>
+          <PickerRow label="Band" value={getFriendlyBandName(band)} defaultExpanded={sheetFocus === 'band' || sheetFocus === null}>
             <div className="flex flex-wrap gap-2 mt-2">
               {(products?.bands ?? []).map((b) => (
                 <button key={b.id} onClick={() => { setBand(b.id); }}
@@ -784,7 +785,8 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
           onBandChange={setBand}
           satellite={satellite}
           sector={sector}
-          onSatelliteClick={() => setBottomSheetOpen(true)}
+          onSatelliteClick={() => { setSheetFocus('satellite'); setBottomSheetOpen(true); }}
+          onSectorClick={() => { setSheetFocus('sector'); setBottomSheetOpen(true); }}
           sectorName={products.sectors?.find((s) => s.id === sector)?.name}
           satelliteAvailability={products.satellite_availability}
         />
@@ -796,6 +798,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
 /** Expandable picker row for bottom sheet */
 function PickerRow({ label, value, children, defaultExpanded = false }: Readonly<{ label: string; value: string; children: React.ReactNode; defaultExpanded?: boolean }>) {
   const [expanded, setExpanded] = useState(defaultExpanded);
+  useEffect(() => { setExpanded(defaultExpanded); }, [defaultExpanded]);
   return (
     <div className="border-b border-white/10 pb-3 last:border-b-0">
       <button onClick={() => setExpanded((v) => !v)} className="w-full flex items-center justify-between py-2" data-testid={`picker-row-${label.toLowerCase()}`}>

--- a/frontend/src/test/BandPillStrip.test.tsx
+++ b/frontend/src/test/BandPillStrip.test.tsx
@@ -16,6 +16,7 @@ const defaultProps = {
   satellite: 'GOES-16',
   sector: 'CONUS',
   onSatelliteClick: vi.fn(),
+  onSectorClick: vi.fn(),
   sectorName: 'CONUS',
 } as const;
 
@@ -55,11 +56,11 @@ describe('BandPillStrip', () => {
     expect(onSatelliteClick).toHaveBeenCalled();
   });
 
-  it('sector chip is tappable and calls onSatelliteClick', () => {
-    const onSatelliteClick = vi.fn();
-    render(<BandPillStrip {...defaultProps} onSatelliteClick={onSatelliteClick} />);
+  it('sector chip is tappable and calls onSectorClick', () => {
+    const onSectorClick = vi.fn();
+    render(<BandPillStrip {...defaultProps} onSectorClick={onSectorClick} />);
     fireEvent.click(screen.getByTestId('pill-strip-sector'));
-    expect(onSatelliteClick).toHaveBeenCalled();
+    expect(onSectorClick).toHaveBeenCalled();
   });
 
   it('shows satellite status when not operational', () => {


### PR DESCRIPTION
Each chip in the BandPillStrip top row now opens the bottom sheet with its respective picker section auto-expanded:

- **Satellite chip** → opens sheet with Satellite picker expanded
- **Sector chip** → opens sheet with Sector picker expanded
- **Band picker** defaults to expanded when no specific focus is set (existing behavior preserved)

### Changes
- **BandPillStrip.tsx**: Added `onSectorClick` prop, wired sector chip to use it
- **LiveTab.tsx**: Added `sheetFocus` state to track which section to auto-expand; passed `defaultExpanded` to each PickerRow based on focus; added `useEffect` in PickerRow to sync with prop changes
- **BandPillStrip.test.tsx**: Updated test to verify sector chip calls `onSectorClick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate sector selection handler for improved event control in data navigation.
  * Enhanced mobile bottom sheet behavior with smart focus state management to automatically expand the relevant picker based on user interaction.

* **Tests**
  * Updated sector interaction tests to reflect new selection handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->