### PR TITLE
refactor: reduce BrowseTab cognitive complexity (S3776)

### DIFF
--- a/frontend/src/components/GoesData/BrowseTab.test.tsx
+++ b/frontend/src/components/GoesData/BrowseTab.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InfiniteScrollSentinel, DesktopBatchActions } from './BrowseTab';
+import type { GoesFrame } from './types';
+
+function makeFrame(id: string): GoesFrame {
+  return {
+    id,
+    satellite: 'GOES-16',
+    sector: 'CONUS',
+    band: 'C02',
+    capture_time: '2024-01-01T00:00:00Z',
+    image_url: `/img/${id}.png`,
+    thumbnail_url: null,
+    file_size: 1024,
+    width: 100,
+    height: 100,
+    tags: [],
+    collections: [],
+  };
+}
+
+describe('InfiniteScrollSentinel', () => {
+  it('renders nothing when hasNextPage is false', () => {
+    const { container } = render(
+      <InfiniteScrollSentinel hasNextPage={false} isFetchingNextPage={false} fetchNextPage={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows loading spinner when fetching next page', () => {
+    render(
+      <InfiniteScrollSentinel hasNextPage={true} isFetchingNextPage={true} fetchNextPage={vi.fn()} />,
+    );
+    // Loader2 renders an svg with animate-spin class
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).toBeTruthy();
+  });
+
+  it('shows Load More button when has next page and not fetching', () => {
+    const fetchNextPage = vi.fn();
+    render(
+      <InfiniteScrollSentinel hasNextPage={true} isFetchingNextPage={false} fetchNextPage={fetchNextPage} />,
+    );
+    const btn = screen.getByRole('button', { name: /load more/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('type', 'button');
+    fireEvent.click(btn);
+    expect(fetchNextPage).toHaveBeenCalledOnce();
+  });
+});
+
+describe('DesktopBatchActions', () => {
+  const baseProps = {
+    frames: [makeFrame('a'), makeFrame('b')],
+    deleteMutation: { mutate: vi.fn() },
+    processMutation: { mutate: vi.fn(), isPending: false },
+    setCollectionFrameIds: vi.fn(),
+    setShowAddToCollection: vi.fn(),
+    setTagFrameIds: vi.fn(),
+    setShowTagModal: vi.fn(),
+    setCompareFrames: vi.fn(),
+  };
+
+  it('renders nothing when no items selected', () => {
+    const { container } = render(
+      <DesktopBatchActions {...baseProps} selectedIds={new Set()} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders action buttons when items are selected', () => {
+    render(
+      <DesktopBatchActions {...baseProps} selectedIds={new Set(['a'])} />,
+    );
+    expect(screen.getByLabelText('Delete selected frames')).toHaveAttribute('type', 'button');
+    expect(screen.getByLabelText('Add to collection')).toHaveAttribute('type', 'button');
+    expect(screen.getByLabelText('Tag selected frames')).toHaveAttribute('type', 'button');
+    expect(screen.getByText('Process')).toBeInTheDocument();
+  });
+
+  it('calls collection handler on click', () => {
+    const props = { ...baseProps, setCollectionFrameIds: vi.fn(), setShowAddToCollection: vi.fn() };
+    render(<DesktopBatchActions {...props} selectedIds={new Set(['a'])} />);
+    fireEvent.click(screen.getByLabelText('Add to collection'));
+    expect(props.setCollectionFrameIds).toHaveBeenCalledWith(['a']);
+    expect(props.setShowAddToCollection).toHaveBeenCalledWith(true);
+  });
+
+  it('calls tag handler on click', () => {
+    const props = { ...baseProps, setTagFrameIds: vi.fn(), setShowTagModal: vi.fn() };
+    render(<DesktopBatchActions {...props} selectedIds={new Set(['a'])} />);
+    fireEvent.click(screen.getByLabelText('Tag selected frames'));
+    expect(props.setTagFrameIds).toHaveBeenCalledWith(['a']);
+    expect(props.setShowTagModal).toHaveBeenCalledWith(true);
+  });
+
+  it('calls process mutation on click', () => {
+    const props = { ...baseProps, processMutation: { mutate: vi.fn(), isPending: false } };
+    render(<DesktopBatchActions {...props} selectedIds={new Set(['a'])} />);
+    fireEvent.click(screen.getByText('Process'));
+    expect(props.processMutation.mutate).toHaveBeenCalledWith(['a']);
+  });
+
+  it('shows Compare button when exactly 2 items selected', () => {
+    render(
+      <DesktopBatchActions {...baseProps} selectedIds={new Set(['a', 'b'])} />,
+    );
+    expect(screen.getByText('Compare')).toBeInTheDocument();
+  });
+
+  it('shows Share button when exactly 1 item selected', () => {
+    render(
+      <DesktopBatchActions {...baseProps} selectedIds={new Set(['a'])} />,
+    );
+    expect(screen.getByText('Share')).toBeInTheDocument();
+  });
+
+  it('does not show Compare when 1 item selected', () => {
+    render(
+      <DesktopBatchActions {...baseProps} selectedIds={new Set(['a'])} />,
+    );
+    expect(screen.queryByText('Compare')).not.toBeInTheDocument();
+  });
+
+  it('calls delete with confirm', () => {
+    globalThis.confirm = vi.fn(() => true);
+    const props = { ...baseProps, deleteMutation: { mutate: vi.fn() } };
+    render(<DesktopBatchActions {...props} selectedIds={new Set(['a'])} />);
+    fireEvent.click(screen.getByLabelText('Delete selected frames'));
+    expect(globalThis.confirm).toHaveBeenCalled();
+    expect(props.deleteMutation.mutate).toHaveBeenCalledWith(['a']);
+  });
+});

--- a/frontend/src/components/GoesData/BrowseTab.tsx
+++ b/frontend/src/components/GoesData/BrowseTab.tsx
@@ -75,7 +75,7 @@ function buildFilterParams(
 }
 
 /* Extracted to reduce BrowseTab cognitive complexity */
-const InfiniteScrollSentinel = forwardRef<HTMLDivElement, Readonly<{
+export const InfiniteScrollSentinel = forwardRef<HTMLDivElement, Readonly<{
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   fetchNextPage: () => void;
@@ -88,6 +88,7 @@ const InfiniteScrollSentinel = forwardRef<HTMLDivElement, Readonly<{
         <Loader2 className="w-6 h-6 animate-spin text-gray-400 dark:text-slate-500" />
       ) : (
         <button
+          type="button"
           onClick={() => fetchNextPage()}
           className="px-6 py-3 text-sm font-medium text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-800 rounded-xl hover:bg-gray-200 dark:hover:bg-slate-700 transition-colors min-h-[44px]"
         >
@@ -98,7 +99,7 @@ const InfiniteScrollSentinel = forwardRef<HTMLDivElement, Readonly<{
   );
 });
 
-function DesktopBatchActions({ selectedIds, frames, deleteMutation, processMutation, setCollectionFrameIds, setShowAddToCollection, setTagFrameIds, setShowTagModal, setCompareFrames }: Readonly<{
+export function DesktopBatchActions({ selectedIds, frames, deleteMutation, processMutation, setCollectionFrameIds, setShowAddToCollection, setTagFrameIds, setShowTagModal, setCompareFrames }: Readonly<{
   selectedIds: Set<string>;
   frames: GoesFrame[];
   deleteMutation: { mutate: (ids: string[]) => void };
@@ -113,25 +114,25 @@ function DesktopBatchActions({ selectedIds, frames, deleteMutation, processMutat
 
   return (
     <div className="hidden md:contents">
-      <button onClick={() => { if (globalThis.confirm(`Delete ${selectedIds.size} frame(s)? This action cannot be undone.`)) deleteMutation.mutate([...selectedIds]); }} aria-label="Delete selected frames"
+      <button type="button" onClick={() => { if (globalThis.confirm(`Delete ${selectedIds.size} frame(s)? This action cannot be undone.`)) deleteMutation.mutate([...selectedIds]); }} aria-label="Delete selected frames"
         className="flex items-center gap-1 px-3 py-1.5 text-xs bg-red-600/20 text-red-400 rounded-lg hover:bg-red-600/30 transition-colors min-h-[44px]">
         <Trash2 className="w-3.5 h-3.5" /> Delete
       </button>
-      <button onClick={() => { setCollectionFrameIds([...selectedIds]); setShowAddToCollection(true); }} aria-label="Add to collection"
+      <button type="button" onClick={() => { setCollectionFrameIds([...selectedIds]); setShowAddToCollection(true); }} aria-label="Add to collection"
         className="flex items-center gap-1 px-3 py-1.5 text-xs bg-gray-200 dark:bg-slate-700 text-gray-600 dark:text-slate-300 rounded-lg hover:bg-gray-200 dark:hover:bg-slate-600 transition-colors min-h-[44px]">
         <FolderPlus className="w-3.5 h-3.5" /> Collection
       </button>
-      <button onClick={() => { setTagFrameIds([...selectedIds]); setShowTagModal(true); }} aria-label="Tag selected frames"
+      <button type="button" onClick={() => { setTagFrameIds([...selectedIds]); setShowTagModal(true); }} aria-label="Tag selected frames"
         className="flex items-center gap-1 px-3 py-1.5 text-xs bg-gray-200 dark:bg-slate-700 text-gray-600 dark:text-slate-300 rounded-lg hover:bg-gray-200 dark:hover:bg-slate-600 transition-colors min-h-[44px]">
         <Tag className="w-3.5 h-3.5" /> Tag
       </button>
-      <button onClick={() => processMutation.mutate([...selectedIds])}
+      <button type="button" onClick={() => processMutation.mutate([...selectedIds])}
         disabled={processMutation.isPending}
         className="flex items-center gap-1 px-3 py-1.5 text-xs bg-primary/20 text-primary rounded-lg hover:bg-primary/30 transition-colors min-h-[44px]">
         <Play className="w-3.5 h-3.5" /> Process
       </button>
       {selectedIds.size === 2 && (
-        <button onClick={() => {
+        <button type="button" onClick={() => {
           const selected = frames.filter((f) => selectedIds.has(f.id));
           if (selected.length === 2) setCompareFrames([selected[0], selected[1]]);
         }}
@@ -140,7 +141,7 @@ function DesktopBatchActions({ selectedIds, frames, deleteMutation, processMutat
         </button>
       )}
       {selectedIds.size === 1 && (
-        <button onClick={async () => {
+        <button type="button" onClick={async () => {
           const frameId = [...selectedIds][0];
           try {
             const res = await api.post(`/goes/frames/${frameId}/share`);


### PR DESCRIPTION
Reduces cognitive complexity from 17 to ≤15 by extracting JSX sub-components. Fixes the pre-existing SonarQube S3776 violation that has been blocking quality gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable infinite-scroll sentinel that shows a loading indicator or a "Load More" button when more items are available.
  * Introduced consolidated desktop batch actions: Delete, Add to Collection, Tag, Process, Compare and Share, with contextual visibility based on selection.

* **Refactor**
  * Replaced inline UI blocks with the new reusable components to improve maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->