### PR TITLE
fix: Live Tab reliability — error boundary reset, zoom deps, prop alignment

### DIFF
--- a/frontend/src/components/GoesData/DesktopControlsBar.tsx
+++ b/frontend/src/components/GoesData/DesktopControlsBar.tsx
@@ -5,7 +5,7 @@ interface DesktopControlsBarProps {
   monitoring: boolean;
   onToggleMonitor: () => void;
   autoFetch: boolean;
-  onAutoFetchChange: React.Dispatch<React.SetStateAction<boolean>>;
+  onAutoFetchChange: (v: boolean) => void;
   refreshInterval: number;
   onRefreshIntervalChange: (v: number) => void;
   compareMode: boolean;
@@ -56,7 +56,7 @@ export default function DesktopControlsBar({ monitoring, onToggleMonitor, autoFe
           aria-label="Toggle auto-fetch"
           aria-checked={autoFetch && !autoFetchDisabled}
           disabled={autoFetchDisabled}
-          onClick={() => onAutoFetchChange((v) => !v)}
+          onClick={autoFetchDisabled ? undefined : () => onAutoFetchChange(!autoFetch)}
           title={autoFetchDisabled ? autoFetchDisabledReason : undefined}
           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${getToggleSwitchClass(autoFetch, autoFetchDisabled)}`}
         >

--- a/frontend/src/components/GoesData/LiveTab.tsx
+++ b/frontend/src/components/GoesData/LiveTab.tsx
@@ -255,6 +255,7 @@ function useLiveFetchJob({
   }, [satellite, sector, band, catalogLatest]);
 
   useEffect(() => {
+    // GEOCOLOR is a pre-rendered composite served via CDN — no raw data to fetch
     if (band === 'GEOCOLOR') return;
     if (!shouldAutoFetch(autoFetch, catalogLatest, frame, lastAutoFetchTimeRef.current, lastAutoFetchMsRef.current)) return;
     lastAutoFetchTimeRef.current = catalogLatest!.scan_time;
@@ -438,7 +439,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
     // Auto-hide on initial load
     resetOverlayTimer();
     return () => clearTimeout(overlayTimer.current);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [resetOverlayTimer]);
   const toggleOverlay = useCallback(() => {
     setOverlayVisible((v) => {
       const next = !v;
@@ -537,7 +538,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
   // Reset zoom when satellite/sector/band changes
   useEffect(() => {
     zoom.reset();
-  }, [satellite, sector, band, zoom]);
+  }, [satellite, sector, band, zoom.reset]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Primary: local frame if available; fallback: catalog CDN URL (responsive)
   const { catalogImageUrl, localImageUrl, imageUrl, prevFrame, prevImageUrl } = resolveImageUrls(catalogLatest, frame, recentFrames, satellite, sector, band, isMobile);
@@ -584,7 +585,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
           onMouseUp={compareMode ? undefined : zoom.handlers.onMouseUp}
           onClick={handleImageTap}
         >
-          <ImageErrorBoundary>
+          <ImageErrorBoundary key={`${satellite}-${sector}-${band}`}>
             {!imageUrl && products?.sectors.find((s) => s.id === sector)?.cdn_available === false && !isLoading ? (
               <MesoFetchRequiredMessage onFetchNow={fetchNow} />
             ) : (
@@ -624,7 +625,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
               monitoring={monitoring}
               onToggleMonitor={toggleMonitor}
               autoFetch={autoFetch}
-              onAutoFetchChange={setAutoFetch}
+              onAutoFetchChange={(v) => setAutoFetch(v)}
               refreshInterval={refreshInterval}
               onRefreshIntervalChange={setRefreshInterval}
               compareMode={compareMode}
@@ -686,7 +687,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
             monitoring={monitoring}
             onToggleMonitor={toggleMonitor}
             autoFetch={autoFetch}
-            onAutoFetchChange={setAutoFetch}
+            onAutoFetchChange={(v) => setAutoFetch(v)}
             autoFetchDisabled={band === 'GEOCOLOR'}
             autoFetchDisabledReason="Auto-fetch not available for GeoColor — CDN images update automatically"
           />


### PR DESCRIPTION
## Changes
- ImageErrorBoundary resets on satellite/sector/band change via key prop
- Fixed zoom reset effect dependency (zoom.reset not zoom object)
- Removed eslint-disable, added resetOverlayTimer to overlay effect deps
- Standardized onAutoFetchChange prop type across Desktop/Mobile controls
- Added explanatory comment for GEOCOLOR auto-fetch skip