### PR TITLE
test: Live Tab sub-component and hook coverage

### DIFF
--- a/frontend/src/components/GoesData/CdnImage.test.tsx
+++ b/frontend/src/components/GoesData/CdnImage.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import CdnImage from './CdnImage';
+
+// Mock the liveTabUtils cache functions
+vi.mock('./liveTabUtils', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('./liveTabUtils');
+  return {
+    ...actual,
+    saveCachedImage: vi.fn(),
+    loadCachedImage: vi.fn(() => null),
+  };
+});
+
+describe('CdnImage', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('renders img with correct src', () => {
+    render(<CdnImage src="https://cdn.example.com/image.jpg" alt="test" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://cdn.example.com/image.jpg');
+  });
+
+  it('shows shimmer while loading', () => {
+    render(<CdnImage src="https://cdn.example.com/image.jpg" alt="test" />);
+    expect(screen.getByTestId('image-shimmer')).toBeInTheDocument();
+  });
+
+  it('hides shimmer after load', () => {
+    render(<CdnImage src="https://cdn.example.com/image.jpg" alt="test" />);
+    fireEvent.load(screen.getByRole('img'));
+    expect(screen.queryByTestId('image-shimmer')).not.toBeInTheDocument();
+  });
+
+  it('shows error state on image error when no cache available', () => {
+    render(<CdnImage src="https://cdn.example.com/broken.jpg" alt="test" />);
+    fireEvent.error(screen.getByRole('img'));
+    expect(screen.getByTestId('cdn-image-error')).toBeInTheDocument();
+    expect(screen.getByText(/Image unavailable/)).toBeInTheDocument();
+  });
+
+  it('auto-retries with cache-buster after error', () => {
+    render(<CdnImage src="https://cdn.example.com/broken.jpg" alt="test" />);
+    fireEvent.error(screen.getByRole('img'));
+    expect(screen.getByTestId('cdn-image-error')).toBeInTheDocument();
+
+    // Advance past 10s retry timer
+    act(() => { vi.advanceTimersByTime(10_000); });
+
+    // Should be back to showing the image (with cache-buster in src)
+    const img = screen.getByRole('img');
+    expect(img.getAttribute('src')).toContain('_r=');
+  });
+
+  it('shows error placeholder when src is empty', () => {
+    render(<CdnImage src="" alt="test" />);
+    expect(screen.getByTestId('cdn-image-error')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/GoesData/DesktopControlsBar.test.tsx
+++ b/frontend/src/components/GoesData/DesktopControlsBar.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DesktopControlsBar from './DesktopControlsBar';
+
+const defaultProps = {
+  monitoring: false,
+  onToggleMonitor: vi.fn(),
+  autoFetch: false,
+  onAutoFetchChange: vi.fn(),
+  refreshInterval: 300000,
+  onRefreshIntervalChange: vi.fn(),
+  compareMode: false,
+  onCompareModeChange: vi.fn(),
+} as const;
+
+describe('DesktopControlsBar', () => {
+  it('renders Watch button', () => {
+    render(<DesktopControlsBar {...defaultProps} />);
+    expect(screen.getByTestId('watch-toggle-btn')).toHaveTextContent('Watch');
+  });
+
+  it('shows Stop Watch when monitoring', () => {
+    render(<DesktopControlsBar {...defaultProps} monitoring={true} />);
+    expect(screen.getByTestId('watch-toggle-btn')).toHaveTextContent('Stop Watch');
+  });
+
+  it('calls onToggleMonitor when Watch is clicked', async () => {
+    const onToggleMonitor = vi.fn();
+    render(<DesktopControlsBar {...defaultProps} onToggleMonitor={onToggleMonitor} />);
+    await userEvent.click(screen.getByTestId('watch-toggle-btn'));
+    expect(onToggleMonitor).toHaveBeenCalledOnce();
+  });
+
+  it('calls onAutoFetchChange when toggle is clicked', async () => {
+    const onAutoFetchChange = vi.fn();
+    render(<DesktopControlsBar {...defaultProps} onAutoFetchChange={onAutoFetchChange} />);
+    await userEvent.click(screen.getByRole('switch', { name: /auto-fetch/i }));
+    expect(onAutoFetchChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not call onAutoFetchChange when disabled', async () => {
+    const onAutoFetchChange = vi.fn();
+    render(<DesktopControlsBar {...defaultProps} onAutoFetchChange={onAutoFetchChange} autoFetchDisabled={true} />);
+    await userEvent.click(screen.getByRole('switch', { name: /auto-fetch/i }));
+    expect(onAutoFetchChange).not.toHaveBeenCalled();
+  });
+
+  it('disables interval select when autoFetch is off', () => {
+    render(<DesktopControlsBar {...defaultProps} autoFetch={false} />);
+    expect(screen.getByLabelText('Auto-fetch interval')).toBeDisabled();
+  });
+
+  it('enables interval select when autoFetch is on', () => {
+    render(<DesktopControlsBar {...defaultProps} autoFetch={true} />);
+    expect(screen.getByLabelText('Auto-fetch interval')).not.toBeDisabled();
+  });
+});

--- a/frontend/src/components/GoesData/StaleDataBanner.test.tsx
+++ b/frontend/src/components/GoesData/StaleDataBanner.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StaleDataBanner from './StaleDataBanner';
+
+describe('StaleDataBanner', () => {
+  const defaultProps = {
+    freshnessInfo: { awsAge: '5m ago', localAge: '15m ago', behindMin: 10 },
+    captureTime: new Date(Date.now() - 2_400_000).toISOString(), // 40 min ago → amber
+    activeJobId: null,
+    onFetchNow: vi.fn(),
+  } as const;
+
+  it('renders warning with behind info', () => {
+    render(<StaleDataBanner {...defaultProps} />);
+    expect(screen.getByText(/10 min behind/)).toBeInTheDocument();
+    expect(screen.getByText('Fetch Now')).toBeInTheDocument();
+  });
+
+  it('calls onFetchNow when Fetch Now is clicked', async () => {
+    const onFetchNow = vi.fn();
+    render(<StaleDataBanner {...defaultProps} onFetchNow={onFetchNow} />);
+    await userEvent.click(screen.getByText('Fetch Now'));
+    expect(onFetchNow).toHaveBeenCalledOnce();
+  });
+
+  it('disables Fetch Now button when activeJobId is set', () => {
+    render(<StaleDataBanner {...defaultProps} activeJobId="job-123" />);
+    expect(screen.getByText('Fetch Now').closest('button')).toBeDisabled();
+  });
+
+  it('returns null when data is fresh and not behind', () => {
+    const { container } = render(
+      <StaleDataBanner
+        freshnessInfo={{ awsAge: '1m ago', localAge: '1m ago', behindMin: 0 }}
+        captureTime={new Date(Date.now() - 60_000).toISOString()}
+        activeJobId={null}
+        onFetchNow={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows stale warning for very old data', () => {
+    render(
+      <StaleDataBanner
+        freshnessInfo={{ awsAge: '10m ago', localAge: '3h ago', behindMin: 170 }}
+        captureTime={new Date(Date.now() - 10_800_000).toISOString()} // 3h ago → red
+        activeJobId={null}
+        onFetchNow={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Data is stale!/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/GoesData/StatusPill.test.tsx
+++ b/frontend/src/components/GoesData/StatusPill.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatusPill from './StatusPill';
+
+describe('StatusPill', () => {
+  it('renders LIVE when not monitoring', () => {
+    render(<StatusPill monitoring={false} satellite="GOES-19" band="C02" frameTime={null} />);
+    expect(screen.getByTestId('status-pill')).toHaveTextContent('LIVE');
+    expect(screen.getByTestId('status-pill')).toHaveTextContent('GOES-19');
+    expect(screen.getByTestId('status-pill')).toHaveTextContent('C02');
+  });
+
+  it('renders MONITORING when monitoring is true', () => {
+    render(<StatusPill monitoring={true} satellite="GOES-18" band="GEOCOLOR" frameTime={null} />);
+    expect(screen.getByTestId('status-pill')).toHaveTextContent('MONITORING');
+  });
+
+  it('shows time ago when frameTime is provided', () => {
+    const recentTime = new Date(Date.now() - 120_000).toISOString(); // 2 min ago
+    render(<StatusPill monitoring={false} satellite="GOES-19" band="C13" frameTime={recentTime} />);
+    expect(screen.getByTestId('status-pill')).toHaveTextContent('2 min ago');
+  });
+
+  it('does not show age when frameTime is null', () => {
+    render(<StatusPill monitoring={false} satellite="GOES-19" band="C02" frameTime={null} />);
+    const pill = screen.getByTestId('status-pill');
+    expect(pill.textContent).not.toMatch(/\d+[mhs]/);
+  });
+});

--- a/frontend/src/hooks/useDoubleTap.test.ts
+++ b/frontend/src/hooks/useDoubleTap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDoubleTap } from './useDoubleTap';
+
+describe('useDoubleTap', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('fires onSingleTap after delay when tapped once', () => {
+    const onSingle = vi.fn();
+    const onDouble = vi.fn();
+    const { result } = renderHook(() => useDoubleTap(onSingle, onDouble, 300));
+
+    act(() => { result.current(); });
+    expect(onSingle).not.toHaveBeenCalled();
+    expect(onDouble).not.toHaveBeenCalled();
+
+    act(() => { vi.advanceTimersByTime(300); });
+    expect(onSingle).toHaveBeenCalledOnce();
+    expect(onDouble).not.toHaveBeenCalled();
+  });
+
+  it('fires onDoubleTap immediately on second tap within delay', () => {
+    const onSingle = vi.fn();
+    const onDouble = vi.fn();
+    const { result } = renderHook(() => useDoubleTap(onSingle, onDouble, 300));
+
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(100); });
+    act(() => { result.current(); });
+
+    expect(onDouble).toHaveBeenCalledOnce();
+    expect(onSingle).not.toHaveBeenCalled();
+
+    // Even after waiting, single tap should not fire
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onSingle).not.toHaveBeenCalled();
+  });
+
+  it('treats taps outside delay as separate single taps', () => {
+    const onSingle = vi.fn();
+    const onDouble = vi.fn();
+    const { result } = renderHook(() => useDoubleTap(onSingle, onDouble, 300));
+
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(onSingle).toHaveBeenCalledOnce();
+
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(onSingle).toHaveBeenCalledTimes(2);
+    expect(onDouble).not.toHaveBeenCalled();
+  });
+
+  it('uses custom delay', () => {
+    const onSingle = vi.fn();
+    const onDouble = vi.fn();
+    const { result } = renderHook(() => useDoubleTap(onSingle, onDouble, 500));
+
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(400); });
+    act(() => { result.current(); });
+
+    expect(onDouble).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/hooks/useImageZoom.test.ts
+++ b/frontend/src/hooks/useImageZoom.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useImageZoom } from './useImageZoom';
+
+describe('useImageZoom', () => {
+  it('starts at scale=1 and not zoomed', () => {
+    const { result } = renderHook(() => useImageZoom());
+    expect(result.current.isZoomed).toBe(false);
+    expect(result.current.style.transform).toContain('scale(1)');
+  });
+
+  it('zoomIn sets scale to doubleTapScale', () => {
+    const { result } = renderHook(() => useImageZoom({ doubleTapScale: 3 }));
+    act(() => { result.current.zoomIn(); });
+    expect(result.current.isZoomed).toBe(true);
+    expect(result.current.style.transform).toContain('scale(3)');
+  });
+
+  it('reset returns to initial state', () => {
+    const { result } = renderHook(() => useImageZoom());
+    act(() => { result.current.zoomIn(); });
+    expect(result.current.isZoomed).toBe(true);
+    act(() => { result.current.reset(); });
+    expect(result.current.isZoomed).toBe(false);
+    expect(result.current.style.transform).toContain('scale(1)');
+  });
+
+  it('wheel zoom in increases scale', () => {
+    const { result } = renderHook(() => useImageZoom());
+    const wheelEvent = {
+      deltaY: -100,
+      preventDefault: () => {},
+    } as unknown as React.WheelEvent;
+
+    act(() => { result.current.handlers.onWheel(wheelEvent); });
+    expect(result.current.isZoomed).toBe(true);
+  });
+
+  it('wheel zoom out from scale=1 stays at scale=1', () => {
+    const { result } = renderHook(() => useImageZoom());
+    const wheelEvent = {
+      deltaY: 100,
+      preventDefault: () => {},
+    } as unknown as React.WheelEvent;
+
+    act(() => { result.current.handlers.onWheel(wheelEvent); });
+    expect(result.current.isZoomed).toBe(false);
+  });
+
+  it('respects maxScale', () => {
+    const { result } = renderHook(() => useImageZoom({ maxScale: 2 }));
+    // Zoom in multiple times
+    const wheelEvent = {
+      deltaY: -100,
+      preventDefault: () => {},
+    } as unknown as React.WheelEvent;
+
+    for (let i = 0; i < 20; i++) {
+      act(() => { result.current.handlers.onWheel(wheelEvent); });
+    }
+    expect(result.current.style.transform).toContain('scale(2)');
+  });
+
+  it('style has correct cursor when zoomed', () => {
+    const { result } = renderHook(() => useImageZoom());
+    expect(result.current.style.cursor).toBe('default');
+    act(() => { result.current.zoomIn(); });
+    expect(result.current.style.cursor).toBe('grab');
+  });
+
+  it('exposes all required handler functions', () => {
+    const { result } = renderHook(() => useImageZoom());
+    const { handlers } = result.current;
+    expect(typeof handlers.onWheel).toBe('function');
+    expect(typeof handlers.onTouchStart).toBe('function');
+    expect(typeof handlers.onTouchMove).toBe('function');
+    expect(typeof handlers.onTouchEnd).toBe('function');
+    expect(typeof handlers.onMouseDown).toBe('function');
+    expect(typeof handlers.onMouseMove).toBe('function');
+    expect(typeof handlers.onMouseUp).toBe('function');
+  });
+});


### PR DESCRIPTION
## Changes
Adds unit tests for previously untested Live Tab components and hooks:
- CdnImage: render, shimmer, error state, auto-retry with cache-buster
- StatusPill: LIVE/MONITORING states, satellite/band info, time ago display
- StaleDataBanner: warning levels, Fetch Now button, null for fresh data
- DesktopControlsBar: watch toggle, auto-fetch toggle, disabled state, interval select
- useImageZoom: initial state, zoom in/out, reset, maxScale, cursor
- useDoubleTap: single tap delay, double tap detection, custom delay

34 new tests across 6 test files.