### PR TITLE
fix: mobile zoom fills viewport instead of staying in aspect-ratio box

### DIFF
--- a/frontend/src/components/GoesData/CdnImage.test.tsx
+++ b/frontend/src/components/GoesData/CdnImage.test.tsx
@@ -57,4 +57,22 @@ describe('CdnImage', () => {
     render(<CdnImage src="" alt="test" />);
     expect(screen.getByTestId('cdn-image-error')).toBeInTheDocument();
   });
+
+  it('uses aspect-ratio 5/3 and object-contain when not zoomed', () => {
+    render(<CdnImage src="https://cdn.example.com/image.jpg" alt="test" />);
+    const container = screen.getByTestId('live-image-container');
+    expect(container.style.aspectRatio).toBe('5 / 3');
+    const img = screen.getByRole('img');
+    expect(img.className).toContain('object-contain');
+  });
+
+  it('removes aspect-ratio and uses object-cover when zoomed', () => {
+    render(<CdnImage src="https://cdn.example.com/image.jpg" alt="test" isZoomed />);
+    const container = screen.getByTestId('live-image-container');
+    expect(container.style.aspectRatio).toBe('');
+    expect(container.className).toContain('h-full');
+    const img = screen.getByRole('img');
+    expect(img.className).toContain('object-cover');
+    expect(img.className).not.toContain('object-contain');
+  });
 });

--- a/frontend/src/components/GoesData/CdnImage.tsx
+++ b/frontend/src/components/GoesData/CdnImage.tsx
@@ -7,9 +7,10 @@ export interface CdnImageProps extends Readonly<React.ImgHTMLAttributes<HTMLImag
   'data-satellite'?: string;
   'data-band'?: string;
   'data-sector'?: string;
+  isZoomed?: boolean;
 }
 
-export default function CdnImage({ src, alt, className, ...props }: Readonly<CdnImageProps>) {
+export default function CdnImage({ src, alt, className, isZoomed = false, ...props }: Readonly<CdnImageProps>) {
   const [error, setError] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [usingCached, setUsingCached] = useState(false);
@@ -102,14 +103,14 @@ export default function CdnImage({ src, alt, className, ...props }: Readonly<Cdn
       {!loaded && !error && (
         <div className="absolute inset-0 animate-pulse bg-gradient-to-r from-slate-800 via-slate-700 to-slate-800 rounded-lg" data-testid="image-shimmer" />
       )}
-      <div className="relative md:rounded-lg overflow-hidden md:border md:border-white/10 w-full bg-slate-900" style={{ aspectRatio: '5/3' }} data-testid="live-image-container">
+      <div className={`relative md:rounded-lg overflow-hidden md:border md:border-white/10 w-full bg-slate-900 ${isZoomed ? 'h-full' : ''}`} style={isZoomed ? undefined : { aspectRatio: '5/3' }} data-testid="live-image-container">
         <img
           src={displaySrc}
           alt={alt}
           onError={handleError}
           onLoad={handleLoad}
           loading="eager"
-          className={`${className ?? ''} w-full h-full object-contain md:rounded-lg transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+          className={`${className ?? ''} w-full h-full ${isZoomed ? 'object-cover' : 'object-contain'} md:rounded-lg transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
           {...props}
         />
       </div>

--- a/frontend/src/components/GoesData/ImagePanelContent.tsx
+++ b/frontend/src/components/GoesData/ImagePanelContent.tsx
@@ -17,9 +17,10 @@ export interface ImagePanelContentProps {
   onPositionChange: (pos: number) => void;
   frameTime: string | null;
   prevFrameTime: string | null;
+  isZoomed?: boolean;
 }
 
-export default function ImagePanelContent({ isLoading, isError, imageUrl, compareMode, satellite, band, sector, zoomStyle, prevImageUrl, comparePosition, onPositionChange, frameTime, prevFrameTime }: Readonly<ImagePanelContentProps>) {
+export default function ImagePanelContent({ isLoading, isError, imageUrl, compareMode, satellite, band, sector, zoomStyle, prevImageUrl, comparePosition, onPositionChange, frameTime, prevFrameTime, isZoomed = false }: Readonly<ImagePanelContentProps>) {
   if (isLoading || (!imageUrl && !isError)) {
     return (
       <div className="w-full h-full flex items-center justify-center" data-testid="loading-shimmer">
@@ -54,9 +55,10 @@ export default function ImagePanelContent({ isLoading, isError, imageUrl, compar
     <CdnImage
       src={imageUrl ?? ''}
       alt={`${satellite} ${band} ${sector}`}
-      className="max-w-full max-h-full object-contain select-none"
+      className="max-w-full max-h-full select-none"
       style={zoomStyle}
       draggable={false}
+      isZoomed={isZoomed}
       data-satellite={satellite}
       data-band={band}
       data-sector={sector}

--- a/frontend/src/components/GoesData/LiveTab.tsx
+++ b/frontend/src/components/GoesData/LiveTab.tsx
@@ -329,7 +329,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
       <div
         ref={containerRef}
         data-testid="live-image-area"
-        className={`relative flex-1 flex items-center justify-center overflow-hidden ${isFullscreen ? 'fixed inset-0 z-50' : ''}`}
+        className={`relative flex-1 flex items-center justify-center ${zoom.isZoomed ? 'overflow-clip' : 'overflow-hidden'} ${isFullscreen ? 'fixed inset-0 z-50' : ''}`}
       >
         {/* Swipe hint (first visit only) */}
         {isMobile && <SwipeHint availableBands={products?.bands?.length} isZoomed={zoom.isZoomed} />}
@@ -378,6 +378,7 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
                 onPositionChange={setComparePosition}
                 frameTime={frame?.capture_time ?? null}
                 prevFrameTime={prevFrame?.capture_time ?? null}
+                isZoomed={zoom.isZoomed}
               />
             )}
           </ImageErrorBoundary>
@@ -453,11 +454,11 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
           </div>
         )}
 
-        {/* Status pill overlay — positioned on image */}
-        <StatusPill monitoring={monitoring} satellite={satellite} band={band} frameTime={frame?.capture_time ?? catalogLatest?.scan_time ?? null} isMobile={isMobile} />
+        {/* Status pill overlay — positioned on image, hidden when zoomed */}
+        {!zoom.isZoomed && <StatusPill monitoring={monitoring} satellite={satellite} band={band} frameTime={frame?.capture_time ?? catalogLatest?.scan_time ?? null} isMobile={isMobile} />}
 
-        {/* Mobile FAB for controls — overlaid on image bottom-right */}
-        <div className="sm:hidden absolute bottom-24 right-4 z-20 flex flex-col items-center gap-1" data-testid="mobile-fab">
+        {/* Mobile FAB for controls — overlaid on image bottom-right, hidden when zoomed */}
+        <div className={`sm:hidden absolute bottom-24 right-4 z-20 flex flex-col items-center gap-1 ${zoom.isZoomed ? 'hidden' : ''}`} data-testid="mobile-fab">
           <MobileControlsFab
             monitoring={monitoring}
             onToggleMonitor={toggleMonitor}


### PR DESCRIPTION
When users pinch-zoom on mobile Live View, the image now fills the
available space instead of being constrained by the 5:3 aspect-ratio
container. Changes:

- CdnImage: accept isZoomed prop; remove aspect-ratio and use
  object-cover when zoomed
- ImagePanelContent: pass isZoomed through to CdnImage
- LiveTab: pass zoom.isZoomed, use overflow-clip when zoomed,
  hide status pill and mobile FAB when zoomed for cleaner UX
- Added tests for zoomed/unzoomed CdnImage behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added image zoom functionality to the satellite data viewer with adaptive display behavior. When zoomed, UI controls are hidden and image scaling adjusts for enhanced viewing. Original behavior is maintained when not zoomed.

* **Tests**
  * Added test coverage for image display behavior in both zoomed and non-zoomed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->