### PR TITLE
fix: standardize card styling and fix light mode contrast

### DIFF
--- a/frontend/src/components/GoesData/AnimationPlayer.tsx
+++ b/frontend/src/components/GoesData/AnimationPlayer.tsx
@@ -159,13 +159,13 @@ export default function AnimationPlayer({ frames, onClose }: Readonly<AnimationP
   return (
     <dialog
       ref={containerRef}
-      className={`fixed inset-0 z-50 bg-space-900 flex flex-col m-0 w-full h-full max-w-none max-h-none border-none p-0 ${
+      className={`fixed inset-0 z-50 bg-gray-100 dark:bg-space-900 flex flex-col m-0 w-full h-full max-w-none max-h-none border-none p-0 ${
         fullscreen ? '' : 'bg-black/95'
       }`}
       aria-label="Animation Player"
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 bg-space-800/80 border-b border-slate-700">
+      <div className="flex items-center justify-between px-4 py-2 bg-gray-200/80 dark:bg-space-800/80 border-b border-gray-300 dark:border-slate-700">
         <div className="text-sm text-slate-300">
           <span className="font-medium text-white">
             Frame {currentIndex + 1}/{frameCount}
@@ -198,7 +198,7 @@ export default function AnimationPlayer({ frames, onClose }: Readonly<AnimationP
       </div>
 
       {/* Controls */}
-      <div className="px-4 py-3 bg-space-800/80 border-t border-slate-700 space-y-2">
+      <div className="px-4 py-3 bg-gray-200/80 dark:bg-space-800/80 border-t border-gray-300 dark:border-slate-700 space-y-2">
         {/* Scrubber */}
         <input
           type="range"

--- a/frontend/src/components/GoesData/DesktopControlsBar.tsx
+++ b/frontend/src/components/GoesData/DesktopControlsBar.tsx
@@ -72,7 +72,7 @@ export default function DesktopControlsBar({ monitoring, onToggleMonitor, autoFe
           className={`rounded bg-white/10 border border-white/20 text-white text-xs px-1.5 py-0.5 transition-opacity ${selectClass}`}
         >
           {REFRESH_INTERVALS.map((ri) => (
-            <option key={ri.value} value={ri.value} className="bg-space-900 text-white">{ri.label}</option>
+            <option key={ri.value} value={ri.value} className="bg-white dark:bg-space-900 text-gray-900 dark:text-white">{ri.label}</option>
           ))}
         </select>
       </div>

--- a/frontend/src/components/Jobs/JobList.tsx
+++ b/frontend/src/components/Jobs/JobList.tsx
@@ -38,7 +38,7 @@ function JobList({ onSelect, limit }: Readonly<Props>) {
     return (
       <div className="space-y-2">
         {["a","b","c"].map((k) => (
-          <div key={k} className="h-14 bg-white dark:bg-space-800/70 rounded-lg animate-pulse" />
+          <div key={k} className="h-14 bg-white dark:bg-space-800/70 rounded-xl animate-pulse" />
         ))}
       </div>
     );
@@ -57,7 +57,7 @@ function JobList({ onSelect, limit }: Readonly<Props>) {
           <button
             type="button"
             key={job.id}
-            className="flex items-center gap-3 flex-wrap sm:flex-nowrap gap-y-2 bg-white dark:bg-space-800 border border-gray-200 dark:border-space-700 rounded-lg px-4 py-3 sm:px-4 sm:py-3 hover:bg-gray-50 dark:hover:bg-space-700 cursor-pointer group transition-colors w-full text-left"
+            className="flex items-center gap-3 flex-wrap sm:flex-nowrap gap-y-2 bg-white dark:bg-space-800 border border-gray-200 dark:border-space-700 rounded-xl px-4 py-3 sm:px-4 sm:py-3 hover:bg-gray-50 dark:hover:bg-space-700 cursor-pointer group transition-colors w-full text-left"
             onClick={() => onSelect?.(job.id)}
           >
             <div className={`p-1.5 rounded-lg ${cfg.bg}`}>
@@ -77,7 +77,7 @@ function JobList({ onSelect, limit }: Readonly<Props>) {
               </p>
             </div>
             {job.status === 'processing' && (
-              <div className="w-20 h-1.5 bg-space-700 rounded-full overflow-hidden">
+              <div className="w-20 h-1.5 bg-gray-200 dark:bg-space-700 rounded-full overflow-hidden">
                 <div
                   className="h-full bg-primary rounded-full transition-all"
                   style={{ width: `${job.progress}%` }}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -146,7 +146,7 @@ export default function Dashboard() {
               style={{ width: `${storagePercent}%` }}
             />
           </div>
-          <p className="text-xs text-gray-500 dark:text-slate-400 mt-1.5">
+          <p className="text-xs text-gray-600 dark:text-slate-400 mt-1.5">
             {formatBytes(storageUsed)} / {formatBytes(storageTotal)}
           </p>
         </div>
@@ -205,12 +205,12 @@ export default function Dashboard() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div className="bg-gray-100 dark:bg-space-800 rounded-lg p-3">
               <p className="text-2xl font-bold text-primary">{totalGoesFrames.toLocaleString()}</p>
-              <p className="text-xs text-gray-500 dark:text-slate-400">Total Frames</p>
+              <p className="text-xs text-gray-600 dark:text-slate-400">Total Frames</p>
             </div>
             {goesStats.frames_by_satellite && Object.entries(goesStats.frames_by_satellite).map(([sat, count]) => (
               <div key={sat} className="bg-gray-100 dark:bg-space-800 rounded-lg p-3">
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">{count.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 dark:text-slate-400">{sat}</p>
+                <p className="text-xs text-gray-600 dark:text-slate-400">{sat}</p>
               </div>
             ))}
             <div className="bg-gray-100 dark:bg-space-800 rounded-lg p-3">
@@ -222,14 +222,14 @@ export default function Dashboard() {
                     : 'Never'}
                 </p>
               </div>
-              <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Last Fetch</p>
+              <p className="text-xs text-gray-600 dark:text-slate-400 mt-1">Last Fetch</p>
             </div>
             <div className="bg-gray-100 dark:bg-space-800 rounded-lg p-3">
               <div className="flex items-center gap-1">
                 <Calendar className="w-3.5 h-3.5 text-gray-500 dark:text-slate-400" />
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">{goesStats.active_schedules}</p>
               </div>
-              <p className="text-xs text-gray-500 dark:text-slate-400">Active Schedules</p>
+              <p className="text-xs text-gray-600 dark:text-slate-400">Active Schedules</p>
             </div>
           </div>
 
@@ -255,7 +255,7 @@ export default function Dashboard() {
                 const colors = ['bg-sky-400', 'bg-violet-400', 'bg-amber-400', 'bg-emerald-400'];
                 return entries.map(([sat, size], i) => (
                   <div key={sat} className="flex items-center gap-3">
-                    <span className="text-xs text-gray-500 dark:text-slate-400 w-20 truncate">{sat}</span>
+                    <span className="text-xs text-gray-600 dark:text-slate-400 w-20 truncate">{sat}</span>
                     <div className="flex-1 h-3 bg-gray-200 dark:bg-space-700 rounded-full overflow-hidden">
                       <div
                         className={`h-full rounded-full ${colors[i % colors.length]}`}
@@ -305,7 +305,7 @@ export default function Dashboard() {
               </div>
               <div>
                 <p className="font-medium text-sm text-gray-900 dark:text-white">1. Watch live imagery</p>
-                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">See real-time GOES satellite feeds</p>
+                <p className="text-xs text-gray-600 dark:text-slate-400 mt-1">See real-time GOES satellite feeds</p>
               </div>
             </Link>
             <Link to="/goes" className="flex items-start gap-3 p-4 bg-gray-100 dark:bg-space-800 rounded-lg hover:bg-gray-200 dark:hover:bg-space-700 transition-colors">
@@ -314,7 +314,7 @@ export default function Dashboard() {
               </div>
               <div>
                 <p className="font-medium text-sm text-gray-900 dark:text-white">2. Browse &amp; fetch frames</p>
-                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Download and explore satellite imagery</p>
+                <p className="text-xs text-gray-600 dark:text-slate-400 mt-1">Download and explore satellite imagery</p>
               </div>
             </Link>
             <Link to="/jobs" className="flex items-start gap-3 p-4 bg-gray-100 dark:bg-space-800 rounded-lg hover:bg-gray-200 dark:hover:bg-space-700 transition-colors">
@@ -323,7 +323,7 @@ export default function Dashboard() {
               </div>
               <div>
                 <p className="font-medium text-sm text-gray-900 dark:text-white">3. Monitor jobs</p>
-                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Track fetch and processing jobs</p>
+                <p className="text-xs text-gray-600 dark:text-slate-400 mt-1">Track fetch and processing jobs</p>
               </div>
             </Link>
           </div>

--- a/frontend/src/test/CardStyling.test.tsx
+++ b/frontend/src/test/CardStyling.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import JobList from '../components/Jobs/JobList';
+
+vi.mock('../hooks/useApi', () => ({
+  useJobs: () => ({
+    data: [
+      { id: '1', status: 'completed', created_at: '2026-01-01T00:00:00Z', status_message: 'Done', progress: 100, type: 'fetch' },
+      { id: '2', status: 'processing', created_at: '2026-01-01T01:00:00Z', status_message: 'Running', progress: 50, type: 'fetch' },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteJob: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+function renderJobList() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <JobList onSelect={vi.fn()} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Card styling consistency', () => {
+  it('job list cards use rounded-xl', () => {
+    const { container } = renderJobList();
+    const buttons = container.querySelectorAll('button');
+    const jobCards = Array.from(buttons).filter((b) => b.className.includes('rounded-xl'));
+    expect(jobCards.length).toBeGreaterThan(0);
+  });
+
+  it('progress bar has light mode background', () => {
+    const { container } = renderJobList();
+    const progressBg = container.querySelector('.bg-gray-200.dark\\:bg-space-700');
+    // The progress bar should have a light mode background class
+    expect(progressBg ?? container.querySelector('[class*="bg-gray-200"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
- Standardize rounded-xl on job list cards
- Fix bg-space-700 missing light mode on JobList progress bar
- Fix bg-space-900/800 missing light mode on AnimationPlayer
- Fix bg-space-900 missing light mode on DesktopControlsBar options
- Upgrade text-gray-500 to text-gray-600 on Dashboard for better contrast
- Add card styling tests
