### PR TITLE
Accessibility improvements across frontend components

### DIFF
--- a/frontend/src/components/GoesData/AnimationStudioTab/StudioFrameSelection.tsx
+++ b/frontend/src/components/GoesData/AnimationStudioTab/StudioFrameSelection.tsx
@@ -36,13 +36,15 @@ export function StudioFrameSelection({
           <Film className="w-5 h-5 text-primary" /> Frame Selection
         </h3>
 
-        <div className="flex gap-2">
+        <div role="group" aria-label="Frame selection mode" className="flex gap-2">
           <button onClick={() => setSelectionMode('filters')}
-            className={`px-3 py-1.5 text-sm rounded-lg ${selectionMode === 'filters' ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
+            aria-pressed={selectionMode === 'filters'}
+            className={`px-3 py-1.5 text-sm rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${selectionMode === 'filters' ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
             By Filters
           </button>
           <button onClick={() => setSelectionMode('collection')}
-            className={`px-3 py-1.5 text-sm rounded-lg ${selectionMode === 'collection' ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
+            aria-pressed={selectionMode === 'collection'}
+            className={`px-3 py-1.5 text-sm rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${selectionMode === 'collection' ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
             From Collection
           </button>
         </div>

--- a/frontend/src/components/GoesData/AnimationStudioTab/StudioHistory.tsx
+++ b/frontend/src/components/GoesData/AnimationStudioTab/StudioHistory.tsx
@@ -36,16 +36,17 @@ export function StudioHistory({ animations, onDelete }: StudioHistoryProps) {
                     <span className="px-2 py-1 text-xs bg-emerald-600/20 text-emerald-400 rounded">Done</span>
                     {anim.output_path && (
                       <a href={`/api/download?path=${encodeURIComponent(anim.output_path)}`}
-                        download className="text-xs text-primary hover:underline">Download</a>
+                        download aria-label={`Download ${anim.name}`} className="text-xs text-primary hover:underline focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden rounded">Download</a>
                     )}
                   </>
                 )}
                 {anim.status === 'failed' && (
-                  <span className="px-2 py-1 text-xs bg-red-600/20 text-red-400 rounded" title={anim.error}>Failed</span>
+                  <span className="px-2 py-1 text-xs bg-red-600/20 text-red-400 rounded" title={anim.error} role="alert">Failed</span>
                 )}
                 <button onClick={() => onDelete(anim.id)}
-                  className="p-1 text-gray-400 dark:text-slate-500 hover:text-red-400 transition-colors">
-                  <Trash2 className="w-4 h-4" />
+                  aria-label={`Delete animation ${anim.name}`}
+                  className="p-1 text-gray-400 dark:text-slate-500 hover:text-red-400 transition-colors focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden rounded">
+                  <Trash2 className="w-4 h-4" aria-hidden="true" />
                 </button>
               </div>
             </div>

--- a/frontend/src/components/GoesData/AnimationStudioTab/StudioSettings.tsx
+++ b/frontend/src/components/GoesData/AnimationStudioTab/StudioSettings.tsx
@@ -52,10 +52,11 @@ export function StudioSettings({
 
         <div>
           <label htmlFor="anim-format" className="block text-xs text-gray-400 dark:text-slate-500 mb-1">Format</label>
-          <div className="flex gap-2">
+          <div role="group" aria-label="Animation format" className="flex gap-2">
             {(['mp4', 'gif'] as const).map((f) => (
               <button key={f} onClick={() => setFormat(f)}
-                className={`px-4 py-1.5 text-sm rounded-lg ${format === f ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
+                aria-pressed={format === f}
+                className={`px-4 py-1.5 text-sm rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${format === f ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
                 {f.toUpperCase()}
               </button>
             ))}
@@ -64,10 +65,11 @@ export function StudioSettings({
 
         <div>
           <label htmlFor="anim-quality" className="block text-xs text-gray-400 dark:text-slate-500 mb-1">Quality</label>
-          <div className="flex gap-2">
+          <div role="group" aria-label="Animation quality" className="flex gap-2">
             {(['low', 'medium', 'high'] as const).map((q) => (
               <button key={q} onClick={() => setQuality(q)}
-                className={`px-3 py-1.5 text-sm rounded-lg capitalize ${quality === q ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
+                aria-pressed={quality === q}
+                className={`px-3 py-1.5 text-sm rounded-lg capitalize focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${quality === q ? 'bg-primary text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400'}`}>
                 {q}
               </button>
             ))}

--- a/frontend/src/components/GoesData/CompareView.tsx
+++ b/frontend/src/components/GoesData/CompareView.tsx
@@ -39,23 +39,27 @@ export default function CompareView({ frameA, frameB, onClose }: Readonly<Compar
       {/* Header */}
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-4">
-          <h2 className="text-lg font-semibold">Compare Frames</h2>
-          <button
-            type="button"
-            onClick={() => setMode('side-by-side')}
-            className={`px-3 py-1 rounded text-sm ${mode === 'side-by-side' ? 'bg-primary text-black' : 'bg-white/10'}`}
-          >
-            Side by Side
-          </button>
-          <button
-            type="button"
-            onClick={() => setMode('slider')}
-            className={`px-3 py-1 rounded text-sm ${mode === 'slider' ? 'bg-primary text-black' : 'bg-white/10'}`}
-          >
-            Slider
-          </button>
+          <h2 className="text-lg font-semibold" id="compare-heading">Compare Frames</h2>
+          <div role="group" aria-label="Comparison view mode">
+            <button
+              type="button"
+              onClick={() => setMode('side-by-side')}
+              aria-pressed={mode === 'side-by-side'}
+              className={`px-3 py-1 rounded text-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${mode === 'side-by-side' ? 'bg-primary text-black' : 'bg-white/10'}`}
+            >
+              Side by Side
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode('slider')}
+              aria-pressed={mode === 'slider'}
+              className={`px-3 py-1 rounded text-sm ml-2 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${mode === 'slider' ? 'bg-primary text-black' : 'bg-white/10'}`}
+            >
+              Slider
+            </button>
+          </div>
         </div>
-        <button type="button" onClick={onClose} className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg">
+        <button type="button" onClick={onClose} aria-label="Close comparison view" className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden">
           Close
         </button>
       </div>
@@ -77,14 +81,14 @@ export default function CompareView({ frameA, frameB, onClose }: Readonly<Compar
             <div className="flex-1 flex items-center justify-center">
               <img
                 src={`/api/goes/frames/${frameA.id}/image`}
-                alt="Frame A"
+                alt={`${frameA.satellite} ${frameA.band} — ${formatTime(frameA.capture_time)}`}
                 className="max-h-full max-w-full object-contain"
               />
             </div>
             <div className="flex-1 flex items-center justify-center">
               <img
                 src={`/api/goes/frames/${frameB.id}/image`}
-                alt="Frame B"
+                alt={`${frameB.satellite} ${frameB.band} — ${formatTime(frameB.capture_time)}`}
                 className="max-h-full max-w-full object-contain"
               />
             </div>
@@ -105,7 +109,7 @@ export default function CompareView({ frameA, frameB, onClose }: Readonly<Compar
             {/* Frame B (full background) */}
             <img
               src={`/api/goes/frames/${frameB.id}/image`}
-              alt="Frame B"
+              alt={`Frame B: ${frameB.satellite} ${frameB.band} — ${formatTime(frameB.capture_time)}`}
               className="absolute inset-0 w-full h-full object-contain"
             />
             {/* Frame A (clipped) */}
@@ -115,7 +119,7 @@ export default function CompareView({ frameA, frameB, onClose }: Readonly<Compar
             >
               <img
                 src={`/api/goes/frames/${frameA.id}/image`}
-                alt="Frame A"
+                alt={`Frame A: ${frameA.satellite} ${frameA.band} — ${formatTime(frameA.capture_time)}`}
                 className="absolute inset-0 w-full h-full object-contain"
                 style={{ width: '100%' }}
               />

--- a/frontend/src/components/GoesData/FrameGallery.tsx
+++ b/frontend/src/components/GoesData/FrameGallery.tsx
@@ -63,7 +63,8 @@ export default function FrameGallery() {
         <select
           value={satellite}
           onChange={(e) => { setSatellite(e.target.value); setPage(1); }}
-          className="px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm"
+          aria-label="Filter by satellite"
+          className="px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden"
         >
           <option value="">All Satellites</option>
           {satellites.map((s) => (
@@ -73,7 +74,8 @@ export default function FrameGallery() {
         <select
           value={band}
           onChange={(e) => { setBand(e.target.value); setPage(1); }}
-          className="px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm"
+          aria-label="Filter by band"
+          className="px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden"
         >
           <option value="">All Bands</option>
           {bands.map((b) => (
@@ -83,13 +85,15 @@ export default function FrameGallery() {
 
         <button
           onClick={() => setCompareMode(!compareMode)}
-          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+          aria-pressed={compareMode}
+          aria-label={`Compare mode${compareMode && compareFrames.length > 0 ? `, ${compareFrames.length} of 2 selected` : ''}`}
+          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${
             compareMode
               ? 'bg-primary text-gray-900 dark:text-white'
               : 'bg-gray-100 dark:bg-slate-800 text-gray-600 dark:text-slate-400 hover:bg-gray-200 dark:hover:bg-slate-700'
           }`}
         >
-          <Columns2 className="w-4 h-4" />
+          <Columns2 className="w-4 h-4" aria-hidden="true" />
           Compare {compareMode && compareFrames.length > 0 ? `(${compareFrames.length}/2)` : ''}
         </button>
 
@@ -113,14 +117,15 @@ export default function FrameGallery() {
         </div>
       )}
       {!isLoading && frames.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+        <div role="grid" aria-label="Satellite image gallery" className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
           {frames.map((frame) => {
             const isSelected = compareFrames.some((f) => f.id === frame.id);
             return (
               <button
                 key={frame.id}
                 onClick={() => (compareMode ? toggleCompareSelect(frame) : setViewerFrame(frame))}
-                className={`group relative rounded-xl overflow-hidden border transition-all hover:shadow-lg ${
+                aria-label={`${frame.satellite} ${frame.band} — ${formatTime(frame.capture_time)}${compareMode ? (isSelected ? ', selected for comparison' : ', select for comparison') : ', click to view'}`}
+                className={`group relative rounded-xl overflow-hidden border transition-all hover:shadow-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${
                   isSelected
                     ? 'border-primary ring-2 ring-primary/50'
                     : 'border-gray-200 dark:border-slate-700 hover:border-primary/50'
@@ -129,17 +134,17 @@ export default function FrameGallery() {
                 <div className="aspect-square bg-gray-100 dark:bg-slate-800">
                   <img
                     src={`/api/goes/frames/${frame.id}/thumbnail`}
-                    alt={`${frame.satellite} ${frame.band}`}
+                    alt={`${frame.satellite} ${frame.band} — ${formatTime(frame.capture_time)}`}
                     className="w-full h-full object-cover"
                     loading="lazy"
                   />
                 </div>
-                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-2 text-left">
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-2 text-left" aria-hidden="true">
                   <p className="text-xs font-medium text-white">{frame.satellite} · {frame.band}</p>
                   <p className="text-[10px] text-white/70">{formatTime(frame.capture_time)}</p>
                 </div>
                 {isSelected && (
-                  <div className="absolute top-2 right-2 w-6 h-6 bg-primary rounded-full flex items-center justify-center text-black text-xs font-bold">
+                  <div className="absolute top-2 right-2 w-6 h-6 bg-primary rounded-full flex items-center justify-center text-black text-xs font-bold" aria-hidden="true">
                     {compareFrames.findIndex((f) => f.id === frame.id) + 1}
                   </div>
                 )}
@@ -151,25 +156,27 @@ export default function FrameGallery() {
 
       {/* Pagination -- keeping same structure */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2">
+        <nav aria-label="Gallery pagination" className="flex items-center justify-center gap-2">
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page <= 1}
-            className="p-2 rounded-lg bg-gray-100 dark:bg-slate-800 disabled:opacity-30"
+            aria-label="Previous page"
+            className="p-2 rounded-lg bg-gray-100 dark:bg-slate-800 disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden"
           >
-            <ChevronLeft className="w-4 h-4" />
+            <ChevronLeft className="w-4 h-4" aria-hidden="true" />
           </button>
-          <span className="text-sm text-gray-600 dark:text-slate-400">
+          <span className="text-sm text-gray-600 dark:text-slate-400" aria-live="polite">
             Page {page} of {totalPages}
           </span>
           <button
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={page >= totalPages}
-            className="p-2 rounded-lg bg-gray-100 dark:bg-slate-800 disabled:opacity-30"
+            aria-label="Next page"
+            className="p-2 rounded-lg bg-gray-100 dark:bg-slate-800 disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden"
           >
-            <ChevronRight className="w-4 h-4" />
+            <ChevronRight className="w-4 h-4" aria-hidden="true" />
           </button>
-        </div>
+        </nav>
       )}
 
       {/* Viewer overlay */}

--- a/frontend/src/components/GoesData/ImageViewer.tsx
+++ b/frontend/src/components/GoesData/ImageViewer.tsx
@@ -66,18 +66,18 @@ export default function ImageViewer({ frame, frames, onClose, onNavigate }: Read
           </span>
         </div>
         <div className="flex items-center gap-2">
-          <button type="button" onClick={() => setScale(scale + 0.5)} className="p-2 hover:bg-white/10 rounded-lg" title="Zoom in">
-            <ZoomIn className="w-5 h-5" />
+          <button type="button" onClick={() => setScale(scale + 0.5)} className="p-2 hover:bg-white/10 rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden" title="Zoom in" aria-label="Zoom in">
+            <ZoomIn className="w-5 h-5" aria-hidden="true" />
           </button>
-          <button type="button" onClick={() => setScale(scale - 0.5)} className="p-2 hover:bg-white/10 rounded-lg" title="Zoom out">
-            <ZoomOut className="w-5 h-5" />
+          <button type="button" onClick={() => setScale(scale - 0.5)} className="p-2 hover:bg-white/10 rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden" title="Zoom out" aria-label="Zoom out">
+            <ZoomOut className="w-5 h-5" aria-hidden="true" />
           </button>
-          <button type="button" onClick={reset} className="p-2 hover:bg-white/10 rounded-lg" title="Reset zoom">
-            <RotateCcw className="w-5 h-5" />
+          <button type="button" onClick={reset} className="p-2 hover:bg-white/10 rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden" title="Reset zoom" aria-label="Reset zoom">
+            <RotateCcw className="w-5 h-5" aria-hidden="true" />
           </button>
-          <span className="text-sm text-white/50 w-16 text-center">{Math.round(scale * 100)}%</span>
-          <button type="button" onClick={onClose} className="p-2 hover:bg-white/10 rounded-lg" title="Close">
-            <X className="w-5 h-5" />
+          <span className="text-sm text-white/50 w-16 text-center" aria-live="polite" aria-label={`Zoom level ${Math.round(scale * 100)}%`}>{Math.round(scale * 100)}%</span>
+          <button type="button" onClick={onClose} className="p-2 hover:bg-white/10 rounded-lg focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden" title="Close" aria-label="Close image viewer">
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -85,8 +85,8 @@ export default function ImageViewer({ frame, frames, onClose, onNavigate }: Read
       {/* Image area */}
       <div ref={containerRef} className="flex-1 relative overflow-hidden flex items-center justify-center">
         {currentIndex > 0 && (
-          <button type="button" onClick={goPrev} className="absolute left-4 z-10 p-3 bg-black/50 hover:bg-black/70 rounded-full text-white">
-            <ChevronLeft className="w-6 h-6" />
+          <button type="button" onClick={goPrev} aria-label="Previous image" className="absolute left-4 z-10 p-3 bg-black/50 hover:bg-black/70 rounded-full text-white focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden">
+            <ChevronLeft className="w-6 h-6" aria-hidden="true" />
           </button>
         )}
 
@@ -113,8 +113,8 @@ export default function ImageViewer({ frame, frames, onClose, onNavigate }: Read
         </button>
 
         {currentIndex < frames.length - 1 && (
-          <button type="button" onClick={goNext} className="absolute right-4 z-10 p-3 bg-black/50 hover:bg-black/70 rounded-full text-white">
-            <ChevronRight className="w-6 h-6" />
+          <button type="button" onClick={goNext} aria-label="Next image" className="absolute right-4 z-10 p-3 bg-black/50 hover:bg-black/70 rounded-full text-white focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden">
+            <ChevronRight className="w-6 h-6" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -53,36 +53,44 @@ export default function NotificationBell() {
         onClick={() => setOpen((v) => !v)}
         className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-space-800 text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white transition-colors focus-ring relative"
         aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : 'Notifications'}
+        aria-haspopup="true"
+        aria-expanded={open}
       >
-        <Bell className="w-4 h-4" />
+        <Bell className="w-4 h-4" aria-hidden="true" />
         {unreadCount > 0 && (
-          <span className="absolute -top-0.5 -right-0.5 w-4 h-4 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center">
+          <span className="absolute -top-0.5 -right-0.5 w-4 h-4 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center" aria-hidden="true">
             {unreadCount > 9 ? '9+' : unreadCount}
           </span>
         )}
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full mt-2 w-80 bg-white dark:bg-space-900 border border-gray-200 dark:border-space-700/50 rounded-xl shadow-xl z-50 overflow-hidden dropdown-enter">
+        <div
+          className="absolute right-0 top-full mt-2 w-80 bg-white dark:bg-space-900 border border-gray-200 dark:border-space-700/50 rounded-xl shadow-xl z-50 overflow-hidden dropdown-enter"
+          role="menu"
+          aria-label="Notifications"
+        >
           <div className="px-4 py-3 border-b border-gray-200 dark:border-space-700/50">
-            <h3 className="text-sm font-semibold">Notifications</h3>
+            <h3 className="text-sm font-semibold" id="notification-heading">Notifications</h3>
           </div>
-          <div className="max-h-64 overflow-y-auto">
+          <div className="max-h-64 overflow-y-auto" role="group" aria-labelledby="notification-heading">
             {(!notifications || notifications.length === 0) ? (
               <div className="px-4 py-6 text-center text-sm text-gray-400 dark:text-slate-500">No notifications</div>
             ) : (
               notifications.slice(0, 10).map((n) => (
                 <button
                   key={n.id}
+                  role="menuitem"
                   onClick={() => {
                     if (!n.read) markReadMutation.mutate(n.id);
                   }}
-                  className={`w-full text-left px-4 py-3 hover:bg-gray-100 dark:hover:bg-space-800 transition-colors border-b border-gray-200 dark:border-space-700/50 last:border-0 ${
+                  aria-label={`${n.read ? '' : 'Unread: '}${n.message} — ${new Date(n.created_at).toLocaleString()}`}
+                  className={`w-full text-left px-4 py-3 hover:bg-gray-100 dark:hover:bg-space-800 transition-colors border-b border-gray-200 dark:border-space-700/50 last:border-0 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-hidden ${
                     n.read ? 'opacity-60' : ''
                   }`}
                 >
                   <div className="flex items-start gap-2">
-                    {!n.read && <span className="w-2 h-2 rounded-full bg-primary mt-1.5 shrink-0" />}
+                    {!n.read && <span className="w-2 h-2 rounded-full bg-primary mt-1.5 shrink-0" aria-hidden="true" />}
                     <div className={n.read ? 'ml-4' : ''}>
                       <p className="text-sm text-gray-600 dark:text-slate-300">{n.message}</p>
                       <p className="text-xs text-gray-400 dark:text-slate-500 mt-0.5">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -98,6 +98,16 @@ body {
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 30%, transparent), 0 0 8px 1px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
+/* Global focus-visible styles for keyboard navigation */
+button:not(.focus-ring):focus-visible,
+a:not(.focus-ring):focus-visible,
+select:not(.focus-ring):focus-visible,
+input[type="checkbox"]:focus-visible,
+input[type="range"]:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 50%, transparent);
+  outline-offset: 2px;
+}
+
 /* Toast slide-in animation */
 @keyframes slide-in {
   from {


### PR DESCRIPTION
## Summary

Focused accessibility improvements across the frontend — no functional changes.

### Changes

**NotificationBell**
- Added `aria-expanded`, `aria-haspopup` to toggle button
- Added `role="menu"` and `aria-label` to dropdown panel
- Added `role="menuitem"` and descriptive `aria-label` (with read/unread status) to notification items
- Added `aria-hidden="true"` to decorative badge elements
- Added `focus-visible` ring styles to notification items

**FrameGallery**
- Added `aria-label` to satellite and band filter `<select>` elements
- Added `aria-pressed` and `aria-label` to compare mode toggle
- Added `role="grid"` and `aria-label` to image gallery grid
- Improved image thumbnail alt text to include capture time
- Added descriptive `aria-label` to each gallery item (context-aware for compare mode)
- Wrapped pagination in `<nav>` landmark with `aria-label`
- Added `aria-label` to previous/next page buttons
- Added `aria-live="polite"` to page counter
- Added `focus-visible` ring to gallery items and pagination buttons

**CompareView**
- Wrapped mode toggle buttons in `role="group"` with `aria-label`
- Improved slider overlay image alt text (now includes satellite, band, time)
- Added `aria-label` to close button
- Added `focus-visible` ring to mode toggles and close button

**ImageViewer**
- Added `aria-label` to previous/next image navigation buttons
- Added `aria-label` to zoom in, zoom out, reset, and close buttons
- Added `aria-hidden="true"` to decorative Lucide icons
- Added `aria-live="polite"` to zoom percentage display
- Added `focus-visible` ring to all toolbar and nav buttons

**AnimationStudioTab (StudioFrameSelection)**
- Added `role="group"` with `aria-label` to frame selection mode toggles
- Added `aria-pressed` to By Filters / From Collection buttons
- Added `focus-visible` ring styles

**AnimationStudioTab (StudioSettings)**
- Added `role="group"` with `aria-label` to format and quality toggle groups
- Added `aria-pressed` to format (MP4/GIF) and quality (low/medium/high) buttons
- Added `focus-visible` ring styles

**AnimationStudioTab (StudioHistory)**
- Added `aria-label` to delete buttons (includes animation name)
- Added `aria-label` to download links
- Added `role="alert"` to failed status indicators
- Added `focus-visible` ring to interactive elements
- Added `aria-hidden="true"` to decorative trash icon

**Global CSS (index.css)**
- Added global `focus-visible` outline styles for buttons, links, selects, checkboxes, and range inputs that don't use the `focus-ring` utility class
- Ensures keyboard users always see a visible focus indicator

### Testing
- All 196 test files pass (1651 tests) — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broad accessibility improvements: better ARIA roles, descriptive labels, and live regions across galleries, viewers, notifications, and controls.
  * Improved keyboard focus handling and clearer selection state announcements for comparing, selecting, downloading, and deleting frames.
  * Image descriptions expanded to include satellite, band, and capture time for clearer context.

* **Style**
  * Added visible focus-ring styling for keyboard users on interactive elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->