### PR TITLE
feat: add Himawari fetch task with S3 segment download

### DIFF
--- a/HIMAWARI_PROGRESS.md
+++ b/HIMAWARI_PROGRESS.md
@@ -1,0 +1,22 @@
+# Himawari Implementation Progress
+
+## Pipeline Status: 🟢 ACTIVE
+
+| PR | Description | Status | PR # | Merged |
+|----|-------------|--------|------|--------|
+| 1 | Satellite registry + dynamic products | ✅ Done | #306 | 2026-03-03 17:38 UTC |
+| 2 | HSD parser + image conversion | ✅ Done | #307 | 2026-03-03 17:53 UTC |
+| 3 | Himawari S3 catalog | ✅ Done | #308 | 2026-03-03 18:08 UTC |
+| 4 | Himawari fetch task | 🔨 Building | — | — |
+| 5 | True Color composite + scheduled fetch | ⏳ Waiting | — | — |
+| 6 | Frontend band names + sector helpers | ⏳ Waiting | — | — |
+| 7 | Live Tab satellite switching | ⏳ Waiting | — | — |
+| 8 | Fetch, Animate, Browse, Presets | ⏳ Waiting | — | — |
+| 9 | API rename /api/goes/ → /api/satellite/ | ⏳ Waiting | — | — |
+| 10 | Auto-prune + disk management | ⏳ Waiting | — | — |
+| 11 | E2E tests + docs | ⏳ Waiting | — | — |
+
+## Cron Job
+- **ID:** 32826174-1f8a-4481-8373-ff64d9d23f0f
+- **Interval:** Every 5 min
+- **Action:** Check CI → merge → spawn next → repeat

--- a/backend/app/routers/goes_fetch.py
+++ b/backend/app/routers/goes_fetch.py
@@ -160,8 +160,19 @@ async def fetch_goes(
     db.add(job)
     await db.commit()
 
-    from ..tasks.fetch_task import fetch_goes_data
-    result = fetch_goes_data.delay(job_id, job.params)
+    # Dispatch to the appropriate fetch task based on satellite type
+    from ..services.satellite_registry import SATELLITE_REGISTRY
+
+    sat_config = SATELLITE_REGISTRY.get(payload.satellite)
+    if sat_config and sat_config.format == "hsd":
+        from ..tasks.himawari_fetch_task import fetch_himawari_data
+        result = fetch_himawari_data.delay(job_id, job.params)
+        message = "Himawari fetch job created"
+    else:
+        from ..tasks.fetch_task import fetch_goes_data
+        result = fetch_goes_data.delay(job_id, job.params)
+        message = "GOES fetch job created"
+
     job.task_id = str(result.id)
     await db.commit()
 
@@ -170,7 +181,7 @@ async def fetch_goes(
     return GoesFetchResponse(
         job_id=job_id,
         status="pending",
-        message="GOES fetch job created",
+        message=message,
     )
 
 

--- a/backend/app/services/satellite_registry.py
+++ b/backend/app/services/satellite_registry.py
@@ -336,7 +336,7 @@ SATELLITE_REGISTRY: dict[str, SatelliteConfig] = {
         availability=dict(_HIMAWARI_AVAILABILITY),
         band_descriptions=dict(_HIMAWARI_BAND_DESCRIPTIONS),
         band_metadata={k: dict(v) for k, v in _HIMAWARI_BAND_METADATA.items()},
-        fetchable=False,  # Fetch pipeline not yet implemented
+        fetchable=True,  # Fetch pipeline implemented in himawari_fetch_task
     ),
 }
 

--- a/backend/app/tasks/himawari_fetch_task.py
+++ b/backend/app/tasks/himawari_fetch_task.py
@@ -1,0 +1,424 @@
+"""Celery task for fetching Himawari-9 AHI data from NOAA S3.
+
+Downloads HSD segments (bz2-compressed), assembles them into full-disk
+images via the lightweight HSD parser, and creates GoesFrame + Image DB
+records identical to the GOES pipeline.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+
+from ..celery_app import celery_app
+from ..config import settings
+from ..services.goes_fetcher import _get_s3_client, _retry_s3_operation
+from ..services.himawari_catalog import (
+    _build_himawari_prefix,
+    _matches_himawari_band,
+    _parse_himawari_filename,
+    list_himawari_timestamps,
+)
+from ..services.himawari_reader import hsd_to_png
+from ..services.satellite_registry import SATELLITE_REGISTRY
+from ..utils import utcnow
+from .helpers import _get_redis, _get_sync_db, _publish_progress, _update_job_db
+
+logger = logging.getLogger(__name__)
+
+# Number of parallel S3 segment downloads
+_SEGMENT_WORKERS = 4
+
+# Expected segments per full-disk band observation
+_EXPECTED_SEGMENTS = 10
+
+
+# ---------------------------------------------------------------------------
+# S3 segment download helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_segments_for_timestamp(
+    bucket: str,
+    sector: str,
+    band: str,
+    scan_time: datetime,
+) -> list[str]:
+    """List all S3 keys for a specific band/sector/timestamp.
+
+    Returns keys sorted by segment number (S01 → S10).
+    """
+    prefix = _build_himawari_prefix(sector, scan_time)
+    s3 = _get_s3_client()
+    paginator = s3.get_paginator("list_objects_v2")
+
+    def _do_list():
+        keys: list[str] = []
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if _matches_himawari_band(key, band):
+                    keys.append(key)
+        return keys
+
+    keys = _retry_s3_operation(_do_list, operation="himawari_list_segments")
+    # Sort by segment number
+    keys.sort(key=lambda k: (_parse_himawari_filename(k) or {}).get("segment", 0))
+    return keys
+
+
+def _download_segment(bucket: str, key: str) -> bytes:
+    """Download a single HSD segment (bz2-compressed) from S3.
+
+    Returns the raw bz2 bytes.
+    """
+    s3 = _get_s3_client()
+
+    def _do_download():
+        resp = s3.get_object(Bucket=bucket, Key=key)
+        return resp["Body"].read()
+
+    return _retry_s3_operation(_do_download, operation="himawari_download_segment")
+
+
+def _download_segments_parallel(
+    bucket: str,
+    keys: list[str],
+) -> list[bytes]:
+    """Download segments in parallel, returning ordered list of bz2 bytes.
+
+    Failed downloads produce empty bytes (``b""``) so the assembler can
+    fill those strips with NaN.
+    """
+    results: dict[int, bytes] = {}
+
+    with ThreadPoolExecutor(max_workers=_SEGMENT_WORKERS) as pool:
+        future_to_idx = {
+            pool.submit(_download_segment, bucket, key): idx
+            for idx, key in enumerate(keys)
+        }
+        for future in as_completed(future_to_idx):
+            idx = future_to_idx[future]
+            try:
+                results[idx] = future.result()
+            except Exception:
+                logger.warning("Failed to download segment %d: %s", idx + 1, keys[idx], exc_info=True)
+                results[idx] = b""
+
+    return [results.get(i, b"") for i in range(len(keys))]
+
+
+# ---------------------------------------------------------------------------
+# DB record creation (mirrors _create_fetch_records in fetch_task.py)
+# ---------------------------------------------------------------------------
+
+
+def _create_himawari_fetch_records(
+    job_id: str,
+    sector: str,
+    output_dir: str,
+    results: list[dict],
+) -> None:
+    """Create Image, GoesFrame, Collection, and CollectionFrame DB records."""
+    from ..db.models import Collection, CollectionFrame, GoesFrame, Image
+    from ..services.thumbnail import generate_thumbnail, get_image_dimensions
+
+    session = _get_sync_db()
+    try:
+        sat = results[0]["satellite"] if results else "Himawari-9"
+        band = results[0]["band"] if results else ""
+        collection_name = f"Himawari Fetch {sat} {sector} {band}"
+        existing_coll = (
+            session.query(Collection)
+            .filter(Collection.name == collection_name)
+            .first()
+        )
+        if existing_coll:
+            collection_id = existing_coll.id
+        else:
+            collection_id = str(uuid.uuid4())
+            collection = Collection(
+                id=collection_id,
+                name=collection_name,
+                description=f"Auto-created from Himawari fetch job {job_id}",
+            )
+            session.add(collection)
+
+        frame_ids: list[str] = []
+        for frame in results:
+            path = Path(frame["path"])
+            file_size = path.stat().st_size if path.exists() else 0
+            width, height = get_image_dimensions(str(path))
+            thumb_path = generate_thumbnail(str(path), output_dir)
+
+            img_record = Image(
+                id=str(uuid.uuid4()),
+                filename=path.name,
+                original_name=path.name,
+                file_path=str(path),
+                file_size=file_size,
+                satellite=frame["satellite"],
+                channel=frame["band"],
+                captured_at=frame["scan_time"],
+                source="himawari_fetch",
+                width=width,
+                height=height,
+            )
+            session.add(img_record)
+
+            gf_id = str(uuid.uuid4())
+            goes_frame = GoesFrame(
+                id=gf_id,
+                satellite=frame["satellite"],
+                sector=sector,
+                band=frame["band"],
+                capture_time=frame["scan_time"],
+                file_path=str(path),
+                file_size=file_size,
+                width=width,
+                height=height,
+                thumbnail_path=thumb_path,
+                source_job_id=job_id,
+            )
+            session.add(goes_frame)
+            frame_ids.append(gf_id)
+
+        session.flush()
+        for gf_id in frame_ids:
+            session.add(CollectionFrame(collection_id=collection_id, frame_id=gf_id))
+
+        session.commit()
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Core fetch logic
+# ---------------------------------------------------------------------------
+
+
+def _read_max_frames_setting() -> int:
+    """Read the max_frames_per_fetch setting from the DB, falling back to default."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from ..db.models import AppSetting
+    from ..services.goes_fetcher import DEFAULT_MAX_FRAMES
+
+    max_frames_limit = DEFAULT_MAX_FRAMES
+    session = _get_sync_db()
+    try:
+        setting = (
+            session.query(AppSetting)
+            .filter(AppSetting.key == "max_frames_per_fetch")
+            .first()
+        )
+        if setting and isinstance(setting.value, (int, float)):
+            max_frames_limit = max(1, min(int(setting.value), 1000))
+    except (SQLAlchemyError, ValueError, TypeError):
+        logger.debug("Could not read max_frames_per_fetch setting, using default")
+    finally:
+        session.close()
+    return max_frames_limit
+
+
+def _execute_himawari_fetch(job_id: str, params: dict, _log) -> None:
+    """Run the core Himawari fetch logic: list timestamps, download segments, process, store."""
+    satellite = params["satellite"]
+    sector = params["sector"]
+    band = params["band"]
+    start_time = datetime.fromisoformat(params["start_time"])
+    end_time = datetime.fromisoformat(params["end_time"])
+    output_dir = str(Path(settings.output_dir) / f"himawari_{job_id}")
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    bucket = SATELLITE_REGISTRY["Himawari-9"].bucket
+
+    # Collect timestamps across all days in the time range
+    all_timestamps: list[dict] = []
+    current_date = start_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_date = end_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    while current_date < end_date:
+        day_timestamps = list_himawari_timestamps(sector, band, current_date)
+        for ts in day_timestamps:
+            scan_dt = datetime.fromisoformat(ts["scan_time"])
+            if start_time <= scan_dt <= end_time:
+                all_timestamps.append(ts)
+        current_date += timedelta(days=1)
+
+    _log(f"Found {len(all_timestamps)} available timestamps on S3")
+    logger.info(
+        "Found %d Himawari timestamps for %s %s %s [%s → %s]",
+        len(all_timestamps), satellite, sector, band,
+        start_time.isoformat(), end_time.isoformat(),
+    )
+
+    if not all_timestamps:
+        msg = (
+            f"No frames found on S3 for {satellite} {sector} {band} "
+            f"between {start_time.strftime('%Y-%m-%d %H:%M')} and "
+            f"{end_time.strftime('%Y-%m-%d %H:%M')}."
+        )
+        _log(msg, "warning")
+        _update_job_db(
+            job_id, status="failed", progress=100,
+            completed_at=utcnow(), status_message=msg,
+        )
+        _publish_progress(job_id, 100, msg, "failed")
+        return
+
+    max_frames_limit = _read_max_frames_setting()
+    was_capped = len(all_timestamps) > max_frames_limit
+    timestamps_to_fetch = all_timestamps[:max_frames_limit]
+
+    results: list[dict] = []
+    failed_downloads = 0
+
+    for i, ts in enumerate(timestamps_to_fetch):
+        scan_time = datetime.fromisoformat(ts["scan_time"])
+
+        # Progress
+        pct = int((i / len(timestamps_to_fetch)) * 100)
+        msg = f"Processing frame {i + 1}/{len(timestamps_to_fetch)}"
+        _publish_progress(job_id, pct, msg)
+        _update_job_db(job_id, progress=pct, status_message=msg)
+        _log(msg)
+
+        try:
+            # List segment keys for this timestamp
+            segment_keys = _list_segments_for_timestamp(bucket, sector, band, scan_time)
+            if not segment_keys:
+                logger.warning("No segments found for %s %s %s at %s", satellite, sector, band, scan_time)
+                failed_downloads += 1
+                continue
+
+            # Download all segments in parallel
+            segment_data = _download_segments_parallel(bucket, segment_keys)
+
+            # Check if we got any actual data
+            valid_segments = sum(1 for s in segment_data if s)
+            if valid_segments == 0:
+                logger.warning("All segment downloads failed for %s at %s", band, scan_time)
+                failed_downloads += 1
+                continue
+
+            logger.info("Downloaded %d/%d segments for %s at %s", valid_segments, len(segment_keys), band, scan_time)
+
+            # Process segments → PNG
+            time_str = scan_time.strftime("%Y%m%d_%H%M")
+            output_path = Path(output_dir) / f"{satellite}_{sector}_{band}_{time_str}.png"
+            hsd_to_png(segment_data, output_path)
+
+            results.append({
+                "satellite": satellite,
+                "sector": sector,
+                "band": band,
+                "scan_time": scan_time,
+                "path": str(output_path),
+            })
+
+        except Exception:
+            logger.exception("Failed to process frame at %s", scan_time)
+            failed_downloads += 1
+
+    # Create DB records
+    if results:
+        _create_himawari_fetch_records(job_id, sector, output_dir, results)
+
+    # Build status message
+    fetched_count = len(results)
+    total_available = len(all_timestamps)
+
+    if fetched_count == 0:
+        if total_available > 0:
+            status_msg = f"All {total_available} frames failed to download"
+        else:
+            status_msg = f"No frames found for {satellite} {sector} {band}"
+        final_status = "failed"
+    elif failed_downloads == 0 and not was_capped:
+        status_msg = f"Fetched {fetched_count} frames"
+        final_status = "completed"
+    else:
+        parts = [f"Fetched {fetched_count} frames"]
+        if failed_downloads > 0:
+            parts.append(f"{failed_downloads} failed to download")
+        if was_capped:
+            beyond = total_available - max_frames_limit
+            parts.append(f"{beyond} beyond frame limit of {max_frames_limit}")
+        status_msg = f"{parts[0]} ({', '.join(parts[1:])})"
+        final_status = "completed_partial"
+
+    _log(status_msg, level="info" if final_status == "completed" else "warning")
+    _update_job_db(
+        job_id, status=final_status, progress=100, output_path=output_dir,
+        completed_at=utcnow(), status_message=status_msg,
+        **({"error": status_msg} if final_status == "completed_partial" else {}),
+    )
+    _publish_progress(job_id, 100, status_msg, final_status)
+
+
+def _make_job_logger(job_id: str):
+    """Return a helper function that writes to the job log."""
+    import redis.exceptions
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from ..services.job_logger import log_job_sync
+
+    def _log(msg: str, level: str = "info") -> None:
+        session = _get_sync_db()
+        try:
+            log_job_sync(session, job_id, msg, level, redis_client=_get_redis())
+        except (SQLAlchemyError, redis.exceptions.RedisError, OSError):
+            logger.debug("Failed to write job log: %s", msg)
+        finally:
+            session.close()
+
+    return _log
+
+
+# ---------------------------------------------------------------------------
+# Celery task
+# ---------------------------------------------------------------------------
+
+
+@celery_app.task(
+    bind=True,
+    name="fetch_himawari_data",
+    autoretry_for=(ConnectionError, TimeoutError, ClientError),
+    max_retries=3,
+    retry_backoff=True,
+    retry_backoff_max=300,
+    retry_jitter=True,
+)
+def fetch_himawari_data(self, job_id: str, params: dict):
+    """Download Himawari HSD segments for a time range, assemble, and create records."""
+    logger.info("Starting Himawari fetch job %s", job_id)
+    _update_job_db(
+        job_id,
+        status="processing",
+        task_id=self.request.id,
+        started_at=utcnow(),
+        status_message="Fetching Himawari data...",
+    )
+    _publish_progress(job_id, 0, "Fetching Himawari data...", "processing")
+
+    _log = _make_job_logger(job_id)
+    _log(f"Himawari fetch started — {params.get('satellite')} {params.get('sector')} {params.get('band')}")
+
+    try:
+        _execute_himawari_fetch(job_id, params, _log)
+    except Exception as e:
+        logger.exception("Himawari fetch job %s failed", job_id)
+        _log(f"Himawari fetch failed: {e}", "error")
+        _update_job_db(
+            job_id,
+            status="failed",
+            error=str(e),
+            completed_at=utcnow(),
+            status_message=f"Error: {e}",
+        )
+        _publish_progress(job_id, 0, f"Error: {e}", "failed")
+        raise

--- a/backend/tests/test_api_contracts.py
+++ b/backend/tests/test_api_contracts.py
@@ -151,7 +151,7 @@ async def test_products_includes_himawari(client: AsyncClient):
     h9 = details["Himawari-9"]
 
     # Verify fetchable flag
-    assert h9["fetchable"] is False
+    assert h9["fetchable"] is True
 
     # Verify Himawari bands present
     h9_band_ids = [b["id"] for b in h9["bands"]]

--- a/backend/tests/test_himawari_fetch.py
+++ b/backend/tests/test_himawari_fetch.py
@@ -1,0 +1,479 @@
+"""Tests for Himawari fetch task (PR 4)."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_redis():
+    with patch("app.tasks.helpers._get_redis") as m:
+        redis_mock = MagicMock()
+        m.return_value = redis_mock
+        yield redis_mock
+
+
+@pytest.fixture
+def mock_sync_db():
+    with patch("app.tasks.helpers._get_sync_db") as m:
+        session = MagicMock()
+        m.return_value = session
+        yield session
+
+
+@pytest.fixture
+def himawari_params():
+    return {
+        "satellite": "Himawari-9",
+        "sector": "FLDK",
+        "band": "B13",
+        "start_time": "2026-03-03T00:00:00+00:00",
+        "end_time": "2026-03-03T01:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _list_segments_for_timestamp
+# ---------------------------------------------------------------------------
+
+class TestListSegments:
+    @patch("app.tasks.himawari_fetch_task._retry_s3_operation")
+    @patch("app.tasks.himawari_fetch_task._get_s3_client")
+    def test_lists_and_sorts_segments(self, mock_client, mock_retry):
+        """Should list S3 keys and sort by segment number."""
+        from app.tasks.himawari_fetch_task import _list_segments_for_timestamp
+
+        # The retry wrapper just calls the function
+        def run_fn(fn, **kwargs):
+            return fn()
+
+        mock_retry.side_effect = run_fn
+
+        mock_paginator = MagicMock()
+        mock_client.return_value.get_paginator.return_value = mock_paginator
+
+        # Return keys for segments 3, 1, 2
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "AHI-L1b-FLDK/2026/03/03/0000/HS_H09_20260303_0000_B13_FLDK_R20_S0310.DAT.bz2"},
+                    {"Key": "AHI-L1b-FLDK/2026/03/03/0000/HS_H09_20260303_0000_B13_FLDK_R20_S0110.DAT.bz2"},
+                    {"Key": "AHI-L1b-FLDK/2026/03/03/0000/HS_H09_20260303_0000_B13_FLDK_R20_S0210.DAT.bz2"},
+                    # A different band — should be excluded
+                    {"Key": "AHI-L1b-FLDK/2026/03/03/0000/HS_H09_20260303_0000_B01_FLDK_R10_S0110.DAT.bz2"},
+                ]
+            }
+        ]
+
+        scan_time = datetime(2026, 3, 3, 0, 0, tzinfo=UTC)
+        keys = _list_segments_for_timestamp("noaa-himawari9", "FLDK", "B13", scan_time)
+
+        # Should have 3 B13 keys, sorted by segment
+        assert len(keys) == 3
+        assert "S01" in keys[0]
+        assert "S02" in keys[1]
+        assert "S03" in keys[2]
+
+
+# ---------------------------------------------------------------------------
+# _download_segments_parallel
+# ---------------------------------------------------------------------------
+
+class TestDownloadSegmentsParallel:
+    @patch("app.tasks.himawari_fetch_task._download_segment")
+    def test_downloads_all_segments(self, mock_download):
+        """Should download all segments and return in order."""
+        from app.tasks.himawari_fetch_task import _download_segments_parallel
+
+        mock_download.side_effect = lambda bucket, key: f"data_{key}".encode()
+        keys = [f"key_{i}" for i in range(10)]
+
+        results = _download_segments_parallel("bucket", keys)
+
+        assert len(results) == 10
+        assert results[0] == b"data_key_0"
+        assert results[9] == b"data_key_9"
+
+    @patch("app.tasks.himawari_fetch_task._download_segment")
+    def test_partial_failure_returns_empty_bytes(self, mock_download):
+        """Failed segments should produce empty bytes."""
+        from app.tasks.himawari_fetch_task import _download_segments_parallel
+
+        def side_effect(bucket, key):
+            if "3" in key:
+                raise ConnectionError("S3 timeout")
+            return f"data_{key}".encode()
+
+        mock_download.side_effect = side_effect
+        keys = [f"key_{i}" for i in range(5)]
+
+        results = _download_segments_parallel("bucket", keys)
+
+        assert len(results) == 5
+        assert results[3] == b""  # Failed segment
+        assert results[0] == b"data_key_0"
+        assert results[4] == b"data_key_4"
+
+
+# ---------------------------------------------------------------------------
+# _create_himawari_fetch_records
+# ---------------------------------------------------------------------------
+
+class TestCreateHimawariFetchRecords:
+    @patch("app.tasks.himawari_fetch_task._get_sync_db")
+    def test_creates_collection_and_frames(self, mock_db, tmp_path):
+        """Should create Collection, GoesFrame, and Image records."""
+        from app.tasks.himawari_fetch_task import _create_himawari_fetch_records
+
+        session = MagicMock()
+        mock_db.return_value = session
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        # Create a fake image file
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"\x89PNG\r\n" + b"\x00" * 100)
+
+        with patch("app.services.thumbnail.generate_thumbnail", return_value=str(tmp_path / "thumb.png")), \
+             patch("app.services.thumbnail.get_image_dimensions", return_value=(5500, 5500)):
+            _create_himawari_fetch_records(
+                "job-1",
+                "FLDK",
+                str(tmp_path),
+                [
+                    {
+                        "satellite": "Himawari-9",
+                        "band": "B13",
+                        "scan_time": datetime(2026, 3, 3, 0, 0, tzinfo=UTC),
+                        "path": str(img_path),
+                    }
+                ],
+            )
+
+        # Should commit with Collection + Image + GoesFrame + CollectionFrame
+        session.add.assert_called()
+        session.flush.assert_called_once()
+        session.commit.assert_called_once()
+
+        # Check we added the right number of records (Collection + Image + GoesFrame + CollectionFrame)
+        assert session.add.call_count == 4
+
+
+# ---------------------------------------------------------------------------
+# _execute_himawari_fetch
+# ---------------------------------------------------------------------------
+
+class TestExecuteHimawariFetch:
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task.hsd_to_png")
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_full_fetch_success(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_list_segs, mock_download, mock_hsd, mock_records,
+        himawari_params, tmp_path,
+    ):
+        """Happy path: finds timestamps, downloads segments, creates records."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+            {"scan_time": "2026-03-03T00:10:00+00:00", "key": "k2", "size": 1000},
+        ]
+        mock_list_segs.return_value = [f"seg_{i}" for i in range(10)]
+        mock_download.return_value = [b"data"] * 10
+        mock_hsd.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        # Should have processed 2 timestamps
+        assert mock_hsd.call_count == 2
+        mock_records.assert_called_once()
+        # Final status should be completed
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "completed"
+
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_no_timestamps_found(
+        self, mock_progress, mock_update, mock_timestamps,
+        himawari_params, tmp_path,
+    ):
+        """Should report failure when no timestamps exist."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        mock_timestamps.return_value = []
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "failed"
+
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task.hsd_to_png")
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_respects_max_frames_limit(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_list_segs, mock_download, mock_hsd, mock_records,
+        himawari_params, tmp_path,
+    ):
+        """Should cap the number of frames to max_frames_per_fetch."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        # Return 5 timestamps, but limit to 2
+        mock_timestamps.return_value = [
+            {"scan_time": f"2026-03-03T00:{i*10:02d}:00+00:00", "key": f"k{i}", "size": 1000}
+            for i in range(5)
+        ]
+        mock_list_segs.return_value = [f"seg_{i}" for i in range(10)]
+        mock_download.return_value = [b"data"] * 10
+        mock_hsd.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=2):
+                _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        # Only 2 frames should be processed
+        assert mock_hsd.call_count == 2
+        # Status should indicate partial
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "completed_partial"
+
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task.hsd_to_png")
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_partial_segment_failure(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_list_segs, mock_download, mock_hsd, mock_records,
+        himawari_params, tmp_path,
+    ):
+        """Should handle partial segment failures gracefully."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+        ]
+        mock_list_segs.return_value = [f"seg_{i}" for i in range(10)]
+        # Return data with some empty segments
+        mock_download.return_value = [b"data"] * 7 + [b""] * 3
+        mock_hsd.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        # Should still produce an image (hsd_to_png handles missing segments)
+        mock_hsd.assert_called_once()
+        mock_records.assert_called_once()
+
+    @patch("app.tasks.himawari_fetch_task.hsd_to_png")
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_all_downloads_fail(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_list_segs, mock_download, mock_hsd,
+        himawari_params, tmp_path,
+    ):
+        """Should report failure when all downloads fail."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+        ]
+        mock_list_segs.return_value = [f"seg_{i}" for i in range(10)]
+        # All segments fail
+        mock_download.return_value = [b""] * 10
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "failed"
+
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task.hsd_to_png", side_effect=Exception("corrupt data"))
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_processing_error_counts_as_failure(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_list_segs, mock_download, mock_hsd, mock_records,
+        himawari_params, tmp_path,
+    ):
+        """hsd_to_png failure should count as a failed download."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+        ]
+        mock_list_segs.return_value = [f"seg_{i}" for i in range(10)]
+        mock_download.return_value = [b"data"] * 10
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "failed"
+        mock_records.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Celery task (fetch_himawari_data)
+# ---------------------------------------------------------------------------
+
+class TestFetchHimawariDataTask:
+    @patch("app.tasks.himawari_fetch_task._execute_himawari_fetch")
+    @patch("app.tasks.himawari_fetch_task._make_job_logger")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_task_calls_execute(self, mock_progress, mock_update, mock_logger, mock_execute, himawari_params):
+        """Task should call _execute_himawari_fetch."""
+        from app.tasks.himawari_fetch_task import fetch_himawari_data
+
+        mock_logger.return_value = MagicMock()
+        fetch_himawari_data("job-1", himawari_params)
+
+        mock_execute.assert_called_once()
+
+    @patch("app.tasks.himawari_fetch_task._execute_himawari_fetch", side_effect=ConnectionError("boom"))
+    @patch("app.tasks.himawari_fetch_task._make_job_logger")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_task_handles_failure(self, mock_progress, mock_update, mock_logger, mock_execute, himawari_params):
+        """Task should update job status on failure and re-raise."""
+        from app.tasks.himawari_fetch_task import fetch_himawari_data
+
+        mock_logger.return_value = MagicMock()
+        with pytest.raises(ConnectionError):
+            fetch_himawari_data("job-1", himawari_params)
+
+        # Should have set status to failed
+        failed_call = [c for c in mock_update.call_args_list if c[1].get("status") == "failed"]
+        assert len(failed_call) == 1
+
+
+# ---------------------------------------------------------------------------
+# Router dispatch (fetch endpoint → Himawari task)
+# ---------------------------------------------------------------------------
+
+class TestFetchEndpointDispatch:
+    """Verify that the fetch endpoint dispatches to the correct task based on satellite type."""
+
+    def test_himawari_satellite_detected_by_format(self):
+        """SATELLITE_REGISTRY should identify Himawari-9 as HSD format."""
+        from app.services.satellite_registry import SATELLITE_REGISTRY
+
+        assert SATELLITE_REGISTRY["Himawari-9"].format == "hsd"
+        assert SATELLITE_REGISTRY["GOES-18"].format == "netcdf"
+
+    def test_dispatch_logic_selects_himawari_for_hsd(self):
+        """The dispatch logic should select Himawari task for HSD satellites."""
+        from app.services.satellite_registry import SATELLITE_REGISTRY
+
+        satellite = "Himawari-9"
+        sat_config = SATELLITE_REGISTRY.get(satellite)
+        assert sat_config is not None
+        assert sat_config.format == "hsd"
+
+    def test_dispatch_logic_selects_goes_for_netcdf(self):
+        """The dispatch logic should select GOES task for NetCDF satellites."""
+        from app.services.satellite_registry import SATELLITE_REGISTRY
+
+        for sat_name in ["GOES-16", "GOES-18", "GOES-19"]:
+            sat_config = SATELLITE_REGISTRY.get(sat_name)
+            assert sat_config is not None
+            assert sat_config.format == "netcdf"
+
+    def test_himawari_is_fetchable(self):
+        """Himawari-9 should be marked as fetchable in the registry."""
+        from app.services.satellite_registry import SATELLITE_REGISTRY
+
+        assert SATELLITE_REGISTRY["Himawari-9"].fetchable is True
+
+
+# ---------------------------------------------------------------------------
+# Progress reporting
+# ---------------------------------------------------------------------------
+
+class TestProgressReporting:
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task.hsd_to_png")
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_progress_reported_for_each_frame(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_list_segs, mock_download, mock_hsd, mock_records,
+        himawari_params, tmp_path,
+    ):
+        """Progress should be published for each frame being processed."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_fetch
+
+        mock_timestamps.return_value = [
+            {"scan_time": f"2026-03-03T00:{i*10:02d}:00+00:00", "key": f"k{i}", "size": 1000}
+            for i in range(3)
+        ]
+        mock_list_segs.return_value = [f"seg_{i}" for i in range(10)]
+        mock_download.return_value = [b"data"] * 10
+        mock_hsd.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_fetch("job-1", himawari_params, _log)
+
+        # Progress should be published for each frame + final
+        progress_calls = mock_progress.call_args_list
+        assert len(progress_calls) >= 4  # 3 frames + 1 final
+
+        # Final progress should be 100
+        final = progress_calls[-1]
+        assert final[0][1] == 100  # progress=100

--- a/backend/tests/test_satellite_registry.py
+++ b/backend/tests/test_satellite_registry.py
@@ -122,9 +122,9 @@ class TestHimawariConfig:
         cfg = get_satellite("Himawari-9")
         assert cfg.format == "hsd"
 
-    def test_himawari_not_fetchable(self):
+    def test_himawari_fetchable(self):
         cfg = get_satellite("Himawari-9")
-        assert cfg.fetchable is False
+        assert cfg.fetchable is True
 
     def test_himawari_bands(self):
         cfg = get_satellite("Himawari-9")


### PR DESCRIPTION
## PR 4: Himawari Fetch Pipeline

Implements the Himawari-9 fetch pipeline that downloads HSD segments from S3, processes them into PNG images, and stores them in the database.

### What's New

**`backend/app/tasks/himawari_fetch_task.py`** — New Celery task:
- `fetch_himawari_data(job_id, params)` — main task entry point
- Lists available timestamps via `himawari_catalog.list_himawari_timestamps()`
- Downloads 10 segments per timestamp in parallel (ThreadPoolExecutor, 4 workers)
- Passes bz2-compressed segments to `hsd_to_png()` for decompression + assembly
- Creates GoesFrame + Image + Collection DB records (satellite="Himawari-9")
- Reports progress via `_publish_progress()` (same pattern as GOES fetch)
- Respects `max_frames_per_fetch` setting from DB
- Handles partial segment failures gracefully (NaN-fills missing strips)

**Router dispatch** (`routers/goes_fetch.py`):
- Detects Himawari satellite via `format == "hsd"` in satellite registry
- Dispatches to `fetch_himawari_data` instead of `fetch_goes_data`
- Same request/response format — no API changes needed
- GOES fetch path completely unchanged

**Registry update** (`satellite_registry.py`):
- Himawari-9 now marked as `fetchable=True`

### Tests (17 tests in `test_himawari_fetch.py`)
- Segment listing and sorting by segment number
- Parallel download with partial failure handling
- DB record creation (Collection, GoesFrame, Image, CollectionFrame)
- Full pipeline: happy path, no data, frame cap, all failures, processing errors
- Celery task error handling and re-raise for retry
- Dispatch logic verification (HSD → Himawari, NetCDF → GOES)
- Progress reporting for each frame

### Dependencies
- PR 1 (satellite_registry) ✅ merged
- PR 2 (himawari_reader) ✅ merged  
- PR 3 (himawari_catalog) ✅ merged

### Test Results
- All 17 new tests pass
- Full suite: 2110 passed, 54 skipped (3 pre-existing websocket failures on main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Himawari-9 satellite data fetching capability with parallel segment download and processing.

* **Documentation**
  * Added Himawari project implementation progress tracking documentation.

* **Tests**
  * Added comprehensive test coverage for Himawari data fetch operations, including success paths, error handling, and progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->