### PR TITLE
feat: add Himawari True Color composite and scheduled fetch

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -15,7 +15,7 @@ celery_app = Celery(
     "satellite_processor",
     broker=settings.celery_broker_url,
     backend=settings.celery_result_backend,
-    include=["app.tasks.processing", "app.tasks.fetch_task", "app.tasks.composite_task", "app.tasks.goes_tasks", "app.tasks.scheduling_tasks", "app.tasks.animation_tasks"],
+    include=["app.tasks.processing", "app.tasks.fetch_task", "app.tasks.composite_task", "app.tasks.goes_tasks", "app.tasks.scheduling_tasks", "app.tasks.animation_tasks", "app.tasks.himawari_fetch_task"],
 )
 
 celery_app.conf.update(
@@ -49,6 +49,8 @@ celery_app.conf.update(
         "generate_composite": {"queue": "default"},
         "check_schedules": {"queue": "default"},
         "run_cleanup": {"queue": "default"},
+        "fetch_himawari_data": {"queue": "default"},
+        "fetch_himawari_true_color": {"queue": "default"},
     },
 
     # Result expiry

--- a/backend/app/models/goes.py
+++ b/backend/app/models/goes.py
@@ -157,7 +157,7 @@ class FetchCompositeRequest(BaseModel):
     @field_validator("recipe")
     @classmethod
     def validate_recipe(cls, v: str) -> str:
-        valid = {"true_color", "natural_color"}
+        valid = {"true_color", "natural_color", "himawari_true_color"}
         if v not in valid:
             raise ValueError(f"Invalid recipe. Must be one of: {valid}")
         return v

--- a/backend/app/routers/_goes_shared.py
+++ b/backend/app/routers/_goes_shared.py
@@ -38,4 +38,5 @@ COMPOSITE_RECIPES = {
     "dust_ash": {"name": "Dust/Ash", "bands": ["C15", "C14", "C13", "C11"]},
     "day_cloud_phase": {"name": "Day Cloud Phase", "bands": ["C13", "C02", "C05"]},
     "airmass": {"name": "Airmass", "bands": ["C08", "C10", "C12", "C13"]},
+    "himawari_true_color": {"name": "Himawari True Color", "bands": ["B03", "B02", "B01"]},
 }

--- a/backend/app/routers/goes_fetch.py
+++ b/backend/app/routers/goes_fetch.py
@@ -41,6 +41,7 @@ async def fetch_composite(
     recipe_bands = {
         "true_color": ["C01", "C02", "C03"],
         "natural_color": ["C02", "C06", "C07"],
+        "himawari_true_color": ["B03", "B02", "B01"],
     }
     bands = recipe_bands.get(payload.recipe)
     if not bands:
@@ -94,8 +95,19 @@ async def fetch_composite(
     db.add(job)
     await db.commit()
 
-    from ..tasks.composite_task import fetch_composite_data
-    result = fetch_composite_data.delay(job_id, job.params)
+    # Dispatch to the appropriate composite task based on satellite type
+    from ..services.satellite_registry import SATELLITE_REGISTRY
+
+    sat_config = SATELLITE_REGISTRY.get(payload.satellite)
+    if sat_config and sat_config.format == "hsd" and payload.recipe == "himawari_true_color":
+        from ..tasks.himawari_fetch_task import fetch_himawari_true_color
+        result = fetch_himawari_true_color.delay(job_id, job.params)
+        message = f"Himawari True Color fetch job created ({len(bands)} bands)"
+    else:
+        from ..tasks.composite_task import fetch_composite_data
+        result = fetch_composite_data.delay(job_id, job.params)
+        message = f"Composite fetch job created ({payload.recipe}, {len(bands)} bands)"
+
     job.task_id = str(result.id)
     await db.commit()
 
@@ -104,7 +116,7 @@ async def fetch_composite(
     return GoesFetchResponse(
         job_id=job_id,
         status="pending",
-        message=f"Composite fetch job created ({payload.recipe}, {len(bands)} bands)",
+        message=message,
     )
 
 

--- a/backend/app/routers/scheduling.py
+++ b/backend/app/routers/scheduling.py
@@ -138,9 +138,21 @@ async def run_fetch_preset(
     db.add(job)
     await db.commit()
 
-    from ..tasks.fetch_task import fetch_goes_data
+    # Dispatch to the correct task based on satellite type
+    from ..services.satellite_registry import SATELLITE_REGISTRY
 
-    fetch_goes_data.delay(job_id, job.params)
+    sat_config = SATELLITE_REGISTRY.get(preset.satellite)
+    if sat_config and sat_config.format == "hsd":
+        if preset.band == "TrueColor":
+            from ..tasks.himawari_fetch_task import fetch_himawari_true_color
+            fetch_himawari_true_color.delay(job_id, job.params)
+        else:
+            from ..tasks.himawari_fetch_task import fetch_himawari_data
+            fetch_himawari_data.delay(job_id, job.params)
+    else:
+        from ..tasks.fetch_task import fetch_goes_data
+        fetch_goes_data.delay(job_id, job.params)
+
     return {"job_id": job_id, "status": "pending", "preset": preset.name}
 
 

--- a/backend/app/tasks/himawari_fetch_task.py
+++ b/backend/app/tasks/himawari_fetch_task.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import numpy as np
 from botocore.exceptions import ClientError
 
 from ..celery_app import celery_app
@@ -382,6 +383,294 @@ def _make_job_logger(job_id: str):
 # ---------------------------------------------------------------------------
 # Celery task
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# True Color composite helpers
+# ---------------------------------------------------------------------------
+
+# Himawari True Color band mapping: R=B03 (0.64µm), G=B02 (0.51µm), B=B01 (0.47µm)
+_TRUE_COLOR_BANDS = ["B03", "B02", "B01"]
+
+
+def _fetch_and_assemble_band(
+    bucket: str,
+    sector: str,
+    band: str,
+    scan_time: datetime,
+) -> np.ndarray | None:
+    """Fetch all segments for a single band and assemble into a full-disk array.
+
+    Returns the raw calibrated float32 array, or None on failure.
+    """
+    from ..services.himawari_reader import assemble_segments, parse_hsd_data, parse_hsd_header
+
+    segment_keys = _list_segments_for_timestamp(bucket, sector, band, scan_time)
+    if not segment_keys:
+        logger.warning("No segments found for %s at %s", band, scan_time)
+        return None
+
+    segment_data = _download_segments_parallel(bucket, segment_keys)
+    valid_count = sum(1 for s in segment_data if s)
+    if valid_count == 0:
+        logger.warning("All segment downloads failed for %s at %s", band, scan_time)
+        return None
+
+    logger.info("Downloaded %d/%d segments for %s at %s", valid_count, len(segment_keys), band, scan_time)
+
+    # Parse each segment
+    parsed: list[np.ndarray | None] = []
+    expected_cols: int | None = None
+    for i, seg_bytes in enumerate(segment_data):
+        if not seg_bytes:
+            parsed.append(None)
+            continue
+        try:
+            import bz2
+            decompressed = bz2.decompress(seg_bytes)
+            header = parse_hsd_header(decompressed)
+            arr = parse_hsd_data(decompressed, header)
+            parsed.append(arr)
+            if expected_cols is None:
+                expected_cols = header.num_columns
+        except Exception:
+            logger.warning("Failed to parse segment %d for %s", i + 1, band, exc_info=True)
+            parsed.append(None)
+
+    # Pad to 10 if needed
+    while len(parsed) < 10:
+        parsed.append(None)
+
+    return assemble_segments(parsed, expected_columns=expected_cols)
+
+
+def _normalize_channel_percentile(
+    data: np.ndarray,
+    pct_low: float = 2.0,
+    pct_high: float = 98.0,
+) -> np.ndarray:
+    """Normalize a single channel to 0–255 uint8 using percentile stretch."""
+    valid = data[np.isfinite(data)]
+    if len(valid) == 0:
+        return np.zeros(data.shape, dtype=np.uint8)
+
+    vmin, vmax = np.nanpercentile(valid, [pct_low, pct_high])
+    if vmax - vmin < 1e-6:
+        vmax = vmin + 1.0
+
+    stretched = np.clip(data, vmin, vmax)
+    stretched = (stretched - vmin) * (255.0 / (vmax - vmin))
+    np.nan_to_num(stretched, nan=0.0, copy=False)
+    return stretched.astype(np.uint8)
+
+
+def _composite_true_color(
+    bands: list[np.ndarray],
+    output_path: Path,
+) -> Path:
+    """Composite three band arrays (R, G, B) into an RGB PNG.
+
+    Each channel is independently normalized using 2nd–98th percentile.
+    Bands may have different resolutions (VIS=11000 cols, IR=5500 cols);
+    all are resized to match the largest.
+
+    Parameters
+    ----------
+    bands : list[np.ndarray]
+        Three float32 arrays [Red, Green, Blue].
+    output_path : Path
+        Where to write the PNG.
+
+    Returns
+    -------
+    Path
+        The output_path written.
+    """
+    from PIL import Image as PILImage
+
+    # Find the largest dimensions (B03/B02/B01 are all VIS so same res, but be safe)
+    max_h = max(b.shape[0] for b in bands)
+    max_w = max(b.shape[1] for b in bands)
+
+    channels = []
+    for band_arr in bands:
+        normalized = _normalize_channel_percentile(band_arr)
+        if normalized.shape[0] != max_h or normalized.shape[1] != max_w:
+            img = PILImage.fromarray(normalized).resize((max_w, max_h), PILImage.BILINEAR)
+            normalized = np.array(img)
+        channels.append(normalized)
+
+    rgb = np.stack(channels, axis=-1)
+    img = PILImage.fromarray(rgb, "RGB")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(str(output_path))
+    return output_path
+
+
+def _execute_himawari_true_color(job_id: str, params: dict, _log) -> None:
+    """Fetch B03, B02, B01 for each timestamp and composite into True Color RGB."""
+    satellite = params["satellite"]
+    sector = params["sector"]
+    start_time = datetime.fromisoformat(params["start_time"])
+    end_time = datetime.fromisoformat(params["end_time"])
+    output_dir = str(Path(settings.output_dir) / f"himawari_tc_{job_id}")
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    bucket = SATELLITE_REGISTRY["Himawari-9"].bucket
+
+    # Use B03 (red) to discover available timestamps
+    all_timestamps: list[dict] = []
+    current_date = start_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_date = end_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    while current_date < end_date:
+        day_timestamps = list_himawari_timestamps(sector, "B03", current_date)
+        for ts in day_timestamps:
+            scan_dt = datetime.fromisoformat(ts["scan_time"])
+            if start_time <= scan_dt <= end_time:
+                all_timestamps.append(ts)
+        current_date += timedelta(days=1)
+
+    _log(f"Found {len(all_timestamps)} available timestamps for True Color")
+    logger.info(
+        "Found %d timestamps for Himawari TrueColor [%s → %s]",
+        len(all_timestamps), start_time.isoformat(), end_time.isoformat(),
+    )
+
+    if not all_timestamps:
+        msg = (
+            f"No frames found on S3 for {satellite} {sector} TrueColor "
+            f"between {start_time.strftime('%Y-%m-%d %H:%M')} and "
+            f"{end_time.strftime('%Y-%m-%d %H:%M')}."
+        )
+        _log(msg, "warning")
+        _update_job_db(
+            job_id, status="failed", progress=100,
+            completed_at=utcnow(), status_message=msg,
+        )
+        _publish_progress(job_id, 100, msg, "failed")
+        return
+
+    max_frames_limit = _read_max_frames_setting()
+    was_capped = len(all_timestamps) > max_frames_limit
+    timestamps_to_fetch = all_timestamps[:max_frames_limit]
+
+    results: list[dict] = []
+    failed_downloads = 0
+
+    for i, ts in enumerate(timestamps_to_fetch):
+        scan_time = datetime.fromisoformat(ts["scan_time"])
+
+        pct = int((i / len(timestamps_to_fetch)) * 100)
+        msg = f"Processing TrueColor frame {i + 1}/{len(timestamps_to_fetch)}"
+        _publish_progress(job_id, pct, msg)
+        _update_job_db(job_id, progress=pct, status_message=msg)
+        _log(msg)
+
+        try:
+            # Fetch all 3 bands (30 segments total)
+            band_arrays: list[np.ndarray | None] = []
+            for band_name in _TRUE_COLOR_BANDS:
+                arr = _fetch_and_assemble_band(bucket, sector, band_name, scan_time)
+                band_arrays.append(arr)
+
+            # Need at least all 3 bands
+            if any(b is None for b in band_arrays):
+                missing = [n for n, b in zip(_TRUE_COLOR_BANDS, band_arrays, strict=False) if b is None]
+                logger.warning("Missing bands %s for TrueColor at %s", missing, scan_time)
+                failed_downloads += 1
+                continue
+
+            # Composite to RGB PNG
+            time_str = scan_time.strftime("%Y%m%d_%H%M")
+            output_path = Path(output_dir) / f"{satellite}_{sector}_TrueColor_{time_str}.png"
+            _composite_true_color(band_arrays, output_path)
+
+            results.append({
+                "satellite": satellite,
+                "sector": sector,
+                "band": "TrueColor",
+                "scan_time": scan_time,
+                "path": str(output_path),
+            })
+
+        except Exception:
+            logger.exception("Failed to process TrueColor frame at %s", scan_time)
+            failed_downloads += 1
+
+    # Create DB records
+    if results:
+        _create_himawari_fetch_records(job_id, sector, output_dir, results)
+
+    # Build status message
+    fetched_count = len(results)
+    total_available = len(all_timestamps)
+
+    if fetched_count == 0:
+        if total_available > 0:
+            status_msg = f"All {total_available} TrueColor frames failed"
+        else:
+            status_msg = f"No frames found for {satellite} {sector} TrueColor"
+        final_status = "failed"
+    elif failed_downloads == 0 and not was_capped:
+        status_msg = f"Fetched {fetched_count} TrueColor frames"
+        final_status = "completed"
+    else:
+        parts = [f"Fetched {fetched_count} TrueColor frames"]
+        if failed_downloads > 0:
+            parts.append(f"{failed_downloads} failed")
+        if was_capped:
+            beyond = total_available - max_frames_limit
+            parts.append(f"{beyond} beyond frame limit of {max_frames_limit}")
+        status_msg = f"{parts[0]} ({', '.join(parts[1:])})"
+        final_status = "completed_partial"
+
+    _log(status_msg, level="info" if final_status == "completed" else "warning")
+    _update_job_db(
+        job_id, status=final_status, progress=100, output_path=output_dir,
+        completed_at=utcnow(), status_message=status_msg,
+        **({"error": status_msg} if final_status == "completed_partial" else {}),
+    )
+    _publish_progress(job_id, 100, status_msg, final_status)
+
+
+@celery_app.task(
+    bind=True,
+    name="fetch_himawari_true_color",
+    autoretry_for=(ConnectionError, TimeoutError, ClientError),
+    max_retries=3,
+    retry_backoff=True,
+    retry_backoff_max=300,
+    retry_jitter=True,
+)
+def fetch_himawari_true_color(self, job_id: str, params: dict):
+    """Fetch Himawari True Color composite (B03+B02+B01) for a time range."""
+    logger.info("Starting Himawari True Color job %s", job_id)
+    _update_job_db(
+        job_id,
+        status="processing",
+        task_id=self.request.id,
+        started_at=utcnow(),
+        status_message="Fetching Himawari True Color...",
+    )
+    _publish_progress(job_id, 0, "Fetching Himawari True Color...", "processing")
+
+    _log = _make_job_logger(job_id)
+    _log(f"Himawari True Color started — {params.get('satellite')} {params.get('sector')}")
+
+    try:
+        _execute_himawari_true_color(job_id, params, _log)
+    except Exception as e:
+        logger.exception("Himawari True Color job %s failed", job_id)
+        _log(f"Himawari True Color failed: {e}", "error")
+        _update_job_db(
+            job_id,
+            status="failed",
+            error=str(e),
+            completed_at=utcnow(),
+            status_message=f"Error: {e}",
+        )
+        _publish_progress(job_id, 0, f"Error: {e}", "failed")
+        raise
 
 
 @celery_app.task(

--- a/backend/app/tasks/scheduling_tasks.py
+++ b/backend/app/tasks/scheduling_tasks.py
@@ -45,8 +45,20 @@ def _launch_schedule_job(session, schedule, preset, now):
 
     logger.info("Scheduled fetch: job=%s preset=%s schedule=%s", job_id, preset.name, schedule.name)
 
-    from .fetch_task import fetch_goes_data
-    fetch_goes_data.delay(job_id, job.params)
+    # Dispatch to the correct task based on satellite type
+    from ..services.satellite_registry import SATELLITE_REGISTRY
+
+    sat_config = SATELLITE_REGISTRY.get(preset.satellite)
+    if sat_config and sat_config.format == "hsd":
+        if preset.band == "TrueColor":
+            from .himawari_fetch_task import fetch_himawari_true_color
+            fetch_himawari_true_color.delay(job_id, job.params)
+        else:
+            from .himawari_fetch_task import fetch_himawari_data
+            fetch_himawari_data.delay(job_id, job.params)
+    else:
+        from .fetch_task import fetch_goes_data
+        fetch_goes_data.delay(job_id, job.params)
 
 
 @celery_app.task(bind=True, name="check_schedules")

--- a/backend/tests/test_himawari_composite.py
+++ b/backend/tests/test_himawari_composite.py
@@ -1,0 +1,674 @@
+"""Tests for Himawari True Color composite (PR 5).
+
+Covers:
+- True Color composite task (3 bands → RGB PNG)
+- TrueColor dispatch from fetch-composite endpoint
+- Composite recipe registration
+- Scheduling dispatch for Himawari presets (TrueColor + single-band)
+- Percentile normalization per channel
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def himawari_tc_params():
+    return {
+        "satellite": "Himawari-9",
+        "sector": "FLDK",
+        "start_time": "2026-03-03T00:00:00+00:00",
+        "end_time": "2026-03-03T01:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Composite recipe registration
+# ---------------------------------------------------------------------------
+
+class TestCompositeRecipeRegistration:
+    def test_himawari_true_color_recipe_exists(self):
+        from app.routers._goes_shared import COMPOSITE_RECIPES
+
+        assert "himawari_true_color" in COMPOSITE_RECIPES
+
+    def test_himawari_true_color_recipe_bands(self):
+        from app.routers._goes_shared import COMPOSITE_RECIPES
+
+        recipe = COMPOSITE_RECIPES["himawari_true_color"]
+        assert recipe["bands"] == ["B03", "B02", "B01"]
+
+    def test_himawari_true_color_recipe_name(self):
+        from app.routers._goes_shared import COMPOSITE_RECIPES
+
+        recipe = COMPOSITE_RECIPES["himawari_true_color"]
+        assert recipe["name"] == "Himawari True Color"
+
+    def test_all_original_recipes_still_exist(self):
+        from app.routers._goes_shared import COMPOSITE_RECIPES
+
+        expected = ["true_color", "natural_color", "fire_detection", "dust_ash", "day_cloud_phase", "airmass"]
+        for name in expected:
+            assert name in COMPOSITE_RECIPES, f"Missing original recipe: {name}"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_channel_percentile
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChannelPercentile:
+    def test_normal_data(self):
+        from app.tasks.himawari_fetch_task import _normalize_channel_percentile
+
+        data = np.random.uniform(0, 100, (100, 100)).astype(np.float32)
+        result = _normalize_channel_percentile(data)
+        assert result.dtype == np.uint8
+        assert result.shape == (100, 100)
+        assert result.min() >= 0
+        assert result.max() <= 255
+
+    def test_all_nan_returns_zeros(self):
+        from app.tasks.himawari_fetch_task import _normalize_channel_percentile
+
+        data = np.full((50, 50), np.nan, dtype=np.float32)
+        result = _normalize_channel_percentile(data)
+        assert result.dtype == np.uint8
+        assert np.all(result == 0)
+
+    def test_constant_data(self):
+        from app.tasks.himawari_fetch_task import _normalize_channel_percentile
+
+        data = np.full((50, 50), 42.0, dtype=np.float32)
+        result = _normalize_channel_percentile(data)
+        assert result.dtype == np.uint8
+        # All same value — should stretch to some valid value
+        assert result.shape == (50, 50)
+
+    def test_nan_pixels_become_zero(self):
+        from app.tasks.himawari_fetch_task import _normalize_channel_percentile
+
+        data = np.array([[1.0, np.nan], [3.0, 4.0]], dtype=np.float32)
+        result = _normalize_channel_percentile(data)
+        assert result[0, 1] == 0  # NaN → 0
+
+
+# ---------------------------------------------------------------------------
+# _composite_true_color
+# ---------------------------------------------------------------------------
+
+class TestCompositeTrueColor:
+    def test_creates_rgb_png(self, tmp_path):
+        from app.tasks.himawari_fetch_task import _composite_true_color
+
+        bands = [
+            np.random.uniform(0, 100, (100, 200)).astype(np.float32),
+            np.random.uniform(0, 100, (100, 200)).astype(np.float32),
+            np.random.uniform(0, 100, (100, 200)).astype(np.float32),
+        ]
+        output = tmp_path / "tc.png"
+        result = _composite_true_color(bands, output)
+
+        assert result == output
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+        # Verify it's a valid RGB image
+        from PIL import Image as PILImage
+        img = PILImage.open(output)
+        assert img.mode == "RGB"
+        assert img.size == (200, 100)
+
+    def test_handles_different_resolutions(self, tmp_path):
+        """Bands with different resolutions should be resized to the largest."""
+        from app.tasks.himawari_fetch_task import _composite_true_color
+
+        bands = [
+            np.random.uniform(0, 100, (200, 400)).astype(np.float32),  # larger
+            np.random.uniform(0, 100, (100, 200)).astype(np.float32),  # smaller
+            np.random.uniform(0, 100, (100, 200)).astype(np.float32),  # smaller
+        ]
+        output = tmp_path / "tc_resize.png"
+        _composite_true_color(bands, output)
+
+        from PIL import Image as PILImage
+        img = PILImage.open(output)
+        assert img.size == (400, 200)  # Should match largest
+
+    def test_creates_parent_directories(self, tmp_path):
+        from app.tasks.himawari_fetch_task import _composite_true_color
+
+        bands = [np.random.uniform(0, 100, (50, 50)).astype(np.float32) for _ in range(3)]
+        output = tmp_path / "nested" / "dir" / "tc.png"
+        _composite_true_color(bands, output)
+        assert output.exists()
+
+    def test_with_nan_pixels(self, tmp_path):
+        """NaN pixels should not crash the composite."""
+        from app.tasks.himawari_fetch_task import _composite_true_color
+
+        bands = []
+        for _ in range(3):
+            arr = np.random.uniform(0, 100, (100, 100)).astype(np.float32)
+            arr[0:10, 0:10] = np.nan  # Some NaN pixels
+            bands.append(arr)
+
+        output = tmp_path / "tc_nan.png"
+        _composite_true_color(bands, output)
+        assert output.exists()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_and_assemble_band
+# ---------------------------------------------------------------------------
+
+class TestFetchAndAssembleBand:
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    def test_returns_none_on_no_segments(self, mock_list, mock_download):
+        from app.tasks.himawari_fetch_task import _fetch_and_assemble_band
+
+        mock_list.return_value = []
+        result = _fetch_and_assemble_band("bucket", "FLDK", "B03", datetime(2026, 3, 3, tzinfo=UTC))
+        assert result is None
+
+    @patch("app.tasks.himawari_fetch_task._download_segments_parallel")
+    @patch("app.tasks.himawari_fetch_task._list_segments_for_timestamp")
+    def test_returns_none_on_all_empty(self, mock_list, mock_download):
+        from app.tasks.himawari_fetch_task import _fetch_and_assemble_band
+
+        mock_list.return_value = [f"seg_{i}" for i in range(10)]
+        mock_download.return_value = [b""] * 10  # All empty
+        result = _fetch_and_assemble_band("bucket", "FLDK", "B03", datetime(2026, 3, 3, tzinfo=UTC))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _execute_himawari_true_color
+# ---------------------------------------------------------------------------
+
+class TestExecuteHimawariTrueColor:
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task._composite_true_color")
+    @patch("app.tasks.himawari_fetch_task._fetch_and_assemble_band")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_full_true_color_success(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_fetch_band, mock_composite, mock_records,
+        himawari_tc_params, tmp_path,
+    ):
+        """Happy path: fetches 3 bands, composites, creates records."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_true_color
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+        ]
+        # Return valid arrays for all 3 bands
+        mock_fetch_band.return_value = np.random.uniform(0, 100, (100, 100)).astype(np.float32)
+        mock_composite.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_true_color("job-1", himawari_tc_params, _log)
+
+        # Should fetch 3 bands (B03, B02, B01)
+        assert mock_fetch_band.call_count == 3
+        mock_composite.assert_called_once()
+        mock_records.assert_called_once()
+
+        # Verify record has band="TrueColor"
+        records_call = mock_records.call_args
+        results = records_call[0][3]  # 4th positional arg
+        assert results[0]["band"] == "TrueColor"
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "completed"
+
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_no_timestamps_fails(
+        self, mock_progress, mock_update, mock_timestamps,
+        himawari_tc_params, tmp_path,
+    ):
+        from app.tasks.himawari_fetch_task import _execute_himawari_true_color
+
+        mock_timestamps.return_value = []
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            _execute_himawari_true_color("job-1", himawari_tc_params, _log)
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "failed"
+
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task._composite_true_color")
+    @patch("app.tasks.himawari_fetch_task._fetch_and_assemble_band")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_missing_band_counts_as_failure(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_fetch_band, mock_composite, mock_records,
+        himawari_tc_params, tmp_path,
+    ):
+        """If one of the 3 bands fails, that timestamp should be skipped."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_true_color
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+        ]
+        # B03 succeeds, B02 fails (None), B01 succeeds
+        mock_fetch_band.side_effect = [
+            np.random.uniform(0, 100, (100, 100)).astype(np.float32),
+            None,  # B02 failed
+            np.random.uniform(0, 100, (100, 100)).astype(np.float32),
+        ]
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_true_color("job-1", himawari_tc_params, _log)
+
+        # Composite should NOT have been called (missing band)
+        mock_composite.assert_not_called()
+        mock_records.assert_not_called()
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "failed"
+
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task._composite_true_color")
+    @patch("app.tasks.himawari_fetch_task._fetch_and_assemble_band")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_multiple_timestamps(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_fetch_band, mock_composite, mock_records,
+        himawari_tc_params, tmp_path,
+    ):
+        """Should process multiple timestamps."""
+        from app.tasks.himawari_fetch_task import _execute_himawari_true_color
+
+        mock_timestamps.return_value = [
+            {"scan_time": "2026-03-03T00:00:00+00:00", "key": "k1", "size": 1000},
+            {"scan_time": "2026-03-03T00:10:00+00:00", "key": "k2", "size": 1000},
+            {"scan_time": "2026-03-03T00:20:00+00:00", "key": "k3", "size": 1000},
+        ]
+        mock_fetch_band.return_value = np.random.uniform(0, 100, (100, 100)).astype(np.float32)
+        mock_composite.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=200):
+                _execute_himawari_true_color("job-1", himawari_tc_params, _log)
+
+        # 3 timestamps × 3 bands = 9 band fetches
+        assert mock_fetch_band.call_count == 9
+        assert mock_composite.call_count == 3
+
+    @patch("app.tasks.himawari_fetch_task._create_himawari_fetch_records")
+    @patch("app.tasks.himawari_fetch_task._composite_true_color")
+    @patch("app.tasks.himawari_fetch_task._fetch_and_assemble_band")
+    @patch("app.tasks.himawari_fetch_task.list_himawari_timestamps")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_respects_max_frames_limit(
+        self, mock_progress, mock_update, mock_timestamps,
+        mock_fetch_band, mock_composite, mock_records,
+        himawari_tc_params, tmp_path,
+    ):
+        from app.tasks.himawari_fetch_task import _execute_himawari_true_color
+
+        mock_timestamps.return_value = [
+            {"scan_time": f"2026-03-03T00:{i*10:02d}:00+00:00", "key": f"k{i}", "size": 1000}
+            for i in range(5)
+        ]
+        mock_fetch_band.return_value = np.random.uniform(0, 100, (100, 100)).astype(np.float32)
+        mock_composite.return_value = Path("/tmp/test.png")
+
+        _log = MagicMock()
+
+        with patch("app.tasks.himawari_fetch_task.settings") as mock_settings:
+            mock_settings.output_dir = str(tmp_path)
+            with patch("app.tasks.himawari_fetch_task._read_max_frames_setting", return_value=2):
+                _execute_himawari_true_color("job-1", himawari_tc_params, _log)
+
+        # Only 2 timestamps × 3 bands = 6
+        assert mock_fetch_band.call_count == 6
+        assert mock_composite.call_count == 2
+
+        final_update = mock_update.call_args_list[-1]
+        assert final_update[1]["status"] == "completed_partial"
+
+
+# ---------------------------------------------------------------------------
+# Celery task (fetch_himawari_true_color)
+# ---------------------------------------------------------------------------
+
+class TestFetchHimawariTrueColorTask:
+    @patch("app.tasks.himawari_fetch_task._execute_himawari_true_color")
+    @patch("app.tasks.himawari_fetch_task._make_job_logger")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_task_calls_execute(self, mock_progress, mock_update, mock_logger, mock_execute, himawari_tc_params):
+        from app.tasks.himawari_fetch_task import fetch_himawari_true_color
+
+        mock_logger.return_value = MagicMock()
+        fetch_himawari_true_color("job-1", himawari_tc_params)
+        mock_execute.assert_called_once()
+
+    @patch("app.tasks.himawari_fetch_task._execute_himawari_true_color", side_effect=ConnectionError("boom"))
+    @patch("app.tasks.himawari_fetch_task._make_job_logger")
+    @patch("app.tasks.himawari_fetch_task._update_job_db")
+    @patch("app.tasks.himawari_fetch_task._publish_progress")
+    def test_task_handles_failure(self, mock_progress, mock_update, mock_logger, mock_execute, himawari_tc_params):
+        from app.tasks.himawari_fetch_task import fetch_himawari_true_color
+
+        mock_logger.return_value = MagicMock()
+        with pytest.raises(ConnectionError):
+            fetch_himawari_true_color("job-1", himawari_tc_params)
+
+        failed_call = [c for c in mock_update.call_args_list if c[1].get("status") == "failed"]
+        assert len(failed_call) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fetch-composite endpoint dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestFetchCompositeDispatch:
+    @patch("app.tasks.himawari_fetch_task.fetch_himawari_true_color.delay")
+    async def test_himawari_true_color_dispatches_to_himawari_task(self, mock_delay, client):
+        """POST /fetch-composite with himawari_true_color recipe should dispatch to Himawari task."""
+        resp = await client.post("/api/goes/fetch-composite", json={
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "recipe": "himawari_true_color",
+            "start_time": "2026-03-03T00:00:00",
+            "end_time": "2026-03-03T01:00:00",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Himawari True Color" in data["message"]
+        mock_delay.assert_called_once()
+
+    @patch("app.tasks.composite_task.fetch_composite_data.delay")
+    async def test_goes_true_color_dispatches_to_goes_task(self, mock_delay, client):
+        """GOES true_color recipe should still dispatch to the GOES composite task."""
+        resp = await client.post("/api/goes/fetch-composite", json={
+            "satellite": "GOES-18",
+            "sector": "CONUS",
+            "recipe": "true_color",
+            "start_time": "2026-03-03T00:00:00",
+            "end_time": "2026-03-03T01:00:00",
+        })
+        assert resp.status_code == 200
+        mock_delay.assert_called_once()
+
+    async def test_himawari_true_color_recipe_accepted(self, client):
+        """The himawari_true_color recipe should be accepted by the validator."""
+        # We just need it to not be a 422 validation error
+        with patch("app.tasks.himawari_fetch_task.fetch_himawari_true_color.delay"):
+            resp = await client.post("/api/goes/fetch-composite", json={
+                "satellite": "Himawari-9",
+                "sector": "FLDK",
+                "recipe": "himawari_true_color",
+                "start_time": "2026-03-03T00:00:00",
+                "end_time": "2026-03-03T01:00:00",
+            })
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Composite recipe endpoint includes Himawari
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestCompositeRecipeEndpoint:
+    async def test_himawari_recipe_in_list(self, client):
+        resp = await client.get("/api/goes/composite-recipes")
+        assert resp.status_code == 200
+        recipes = resp.json()
+        ids = [r["id"] for r in recipes]
+        assert "himawari_true_color" in ids
+
+    async def test_himawari_recipe_has_correct_bands(self, client):
+        resp = await client.get("/api/goes/composite-recipes")
+        for recipe in resp.json():
+            if recipe["id"] == "himawari_true_color":
+                assert recipe["bands"] == ["B03", "B02", "B01"]
+                break
+        else:
+            pytest.fail("himawari_true_color not found in recipes")
+
+
+# ---------------------------------------------------------------------------
+# Scheduling dispatch for Himawari
+# ---------------------------------------------------------------------------
+
+class TestSchedulingDispatch:
+    def test_scheduling_dispatches_himawari_single_band(self):
+        """_launch_schedule_job should use fetch_himawari_data for Himawari single-band presets."""
+        from app.tasks.scheduling_tasks import _launch_schedule_job
+
+        session = MagicMock()
+        schedule = MagicMock()
+        schedule.interval_minutes = 10
+
+        preset = MagicMock()
+        preset.satellite = "Himawari-9"
+        preset.sector = "FLDK"
+        preset.band = "B13"
+        preset.id = "preset-1"
+        preset.name = "Test"
+
+        now = datetime(2026, 3, 3, 0, 0, tzinfo=UTC)
+
+        with patch("app.tasks.himawari_fetch_task.fetch_himawari_data.delay") as mock_delay:
+            _launch_schedule_job(session, schedule, preset, now)
+            mock_delay.assert_called_once()
+
+    def test_scheduling_dispatches_himawari_true_color(self):
+        """_launch_schedule_job should use fetch_himawari_true_color for TrueColor presets."""
+        from app.tasks.scheduling_tasks import _launch_schedule_job
+
+        session = MagicMock()
+        schedule = MagicMock()
+        schedule.interval_minutes = 10
+
+        preset = MagicMock()
+        preset.satellite = "Himawari-9"
+        preset.sector = "FLDK"
+        preset.band = "TrueColor"
+        preset.id = "preset-2"
+        preset.name = "TrueColor Preset"
+
+        now = datetime(2026, 3, 3, 0, 0, tzinfo=UTC)
+
+        with patch("app.tasks.himawari_fetch_task.fetch_himawari_true_color.delay") as mock_delay:
+            _launch_schedule_job(session, schedule, preset, now)
+            mock_delay.assert_called_once()
+
+    def test_scheduling_dispatches_goes_unchanged(self):
+        """_launch_schedule_job should still use fetch_goes_data for GOES presets."""
+        from app.tasks.scheduling_tasks import _launch_schedule_job
+
+        session = MagicMock()
+        schedule = MagicMock()
+        schedule.interval_minutes = 10
+
+        preset = MagicMock()
+        preset.satellite = "GOES-18"
+        preset.sector = "CONUS"
+        preset.band = "C02"
+        preset.id = "preset-3"
+        preset.name = "GOES Preset"
+
+        now = datetime(2026, 3, 3, 0, 0, tzinfo=UTC)
+
+        with patch("app.tasks.fetch_task.fetch_goes_data.delay") as mock_delay:
+            _launch_schedule_job(session, schedule, preset, now)
+            mock_delay.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Scheduling endpoint dispatch for Himawari presets
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSchedulingEndpointDispatch:
+    async def test_create_himawari_preset(self, client):
+        """Should be able to create a Himawari preset with TrueColor band."""
+        resp = await client.post("/api/goes/fetch-presets", json={
+            "name": "Himawari FLDK TrueColor",
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "band": "TrueColor",
+            "description": "Auto-fetch Himawari True Color",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["satellite"] == "Himawari-9"
+        assert data["band"] == "TrueColor"
+
+    async def test_create_himawari_single_band_preset(self, client):
+        """Should be able to create a Himawari preset with a single band."""
+        resp = await client.post("/api/goes/fetch-presets", json={
+            "name": "Himawari FLDK B13",
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "band": "B13",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["satellite"] == "Himawari-9"
+        assert data["band"] == "B13"
+
+    async def test_create_himawari_schedule(self, client):
+        """Should be able to create a schedule with a Himawari preset."""
+        # Create preset
+        resp = await client.post("/api/goes/fetch-presets", json={
+            "name": "Sched Preset",
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "band": "TrueColor",
+        })
+        preset_id = resp.json()["id"]
+
+        # Create schedule
+        resp = await client.post("/api/goes/schedules", json={
+            "name": "Every 10 min",
+            "preset_id": preset_id,
+            "interval_minutes": 10,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["interval_minutes"] == 10
+
+    async def test_run_himawari_true_color_preset(self, client, monkeypatch):
+        """Running a Himawari TrueColor preset should dispatch to fetch_himawari_true_color."""
+        called = {}
+
+        class FakeTask:
+            def delay(self, job_id, params):
+                called["job_id"] = job_id
+                called["params"] = params
+
+        import app.tasks.himawari_fetch_task as h_mod
+        monkeypatch.setattr(h_mod, "fetch_himawari_true_color", FakeTask())
+
+        resp = await client.post("/api/goes/fetch-presets", json={
+            "name": "Run TC",
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "band": "TrueColor",
+        })
+        pid = resp.json()["id"]
+        resp = await client.post(f"/api/goes/fetch-presets/{pid}/run")
+        assert resp.status_code == 200
+        assert "job_id" in called
+        assert called["params"]["band"] == "TrueColor"
+
+    async def test_run_himawari_single_band_preset(self, client, monkeypatch):
+        """Running a Himawari single-band preset should dispatch to fetch_himawari_data."""
+        called = {}
+
+        class FakeTask:
+            def delay(self, job_id, params):
+                called["job_id"] = job_id
+                called["params"] = params
+
+        import app.tasks.himawari_fetch_task as h_mod
+        monkeypatch.setattr(h_mod, "fetch_himawari_data", FakeTask())
+
+        resp = await client.post("/api/goes/fetch-presets", json={
+            "name": "Run B13",
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "band": "B13",
+        })
+        pid = resp.json()["id"]
+        resp = await client.post(f"/api/goes/fetch-presets/{pid}/run")
+        assert resp.status_code == 200
+        assert "job_id" in called
+        assert called["params"]["band"] == "B13"
+
+
+# ---------------------------------------------------------------------------
+# TrueColor band validation (blocked from direct fetch)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestTrueColorBandValidation:
+    async def test_truecolor_blocked_in_direct_fetch(self, client):
+        """TrueColor should NOT be allowed in the direct /fetch endpoint."""
+        resp = await client.post("/api/goes/fetch", json={
+            "satellite": "Himawari-9",
+            "sector": "FLDK",
+            "band": "TrueColor",
+            "start_time": "2026-03-03T00:00:00",
+            "end_time": "2026-03-03T01:00:00",
+        })
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        if isinstance(detail, list):
+            assert any("composite" in str(e).lower() for e in detail)
+        else:
+            assert "composite" in str(detail).lower()
+
+
+# ---------------------------------------------------------------------------
+# Celery app registration
+# ---------------------------------------------------------------------------
+
+class TestCeleryRegistration:
+    def test_himawari_fetch_task_in_includes(self):
+        from app.celery_app import celery_app
+        assert "app.tasks.himawari_fetch_task" in celery_app.conf.include
+
+    def test_himawari_task_routes_exist(self):
+        from app.celery_app import celery_app
+        routes = celery_app.conf.task_routes
+        assert "fetch_himawari_data" in routes
+        assert "fetch_himawari_true_color" in routes


### PR DESCRIPTION
## PR 5: Himawari True Color Composite + Scheduled Fetch

### Summary
Adds True Color RGB compositing for Himawari-9 and wires Himawari into the existing scheduling system.

### Part 1: True Color Composite

**New Celery task: `fetch_himawari_true_color`**
- Fetches B03 (Red 0.64µm), B02 (Green 0.51µm), B01 (Blue 0.47µm) for each timestamp
- Downloads 30 segments total (10 per band) in parallel
- Assembles each band independently via `himawari_reader`
- Composites into RGB image with per-channel 2nd-98th percentile normalization
- Handles different band resolutions (auto-resize to largest)
- Saves as PNG, stores as GoesFrame with `band="TrueColor"`

**Endpoint wiring:**
- `POST /api/goes/fetch-composite` with `recipe="himawari_true_color"` dispatches to `fetch_himawari_true_color`
- `himawari_true_color` recipe added to `COMPOSITE_RECIPES` and recipe validator
- TrueColor blocked from direct `/api/goes/fetch` endpoint (must use composite pipeline)

### Part 2: Scheduled Auto-Fetch

Uses the **existing scheduling system** (presets + schedules in DB) rather than a hardcoded beat schedule:
- Himawari presets (including TrueColor) can be created via `/api/goes/fetch-presets`
- Schedules can be created via `/api/goes/schedules` (e.g., every 10 minutes)
- `_launch_schedule_job` and `run_fetch_preset` correctly dispatch to:
  - `fetch_himawari_true_color` for TrueColor band
  - `fetch_himawari_data` for single bands (B01-B16)
  - `fetch_goes_data` for GOES satellites (unchanged)

### Files Changed
- `backend/app/tasks/himawari_fetch_task.py` — True Color task + helpers
- `backend/app/routers/_goes_shared.py` — `himawari_true_color` recipe
- `backend/app/routers/goes_fetch.py` — Composite dispatch logic
- `backend/app/routers/scheduling.py` — Preset run dispatch
- `backend/app/tasks/scheduling_tasks.py` — Schedule dispatch
- `backend/app/models/goes.py` — Recipe validator
- `backend/app/celery_app.py` — Task registration
- `backend/tests/test_himawari_composite.py` — 37 new tests

### Tests
All 2158 tests pass (37 new). Ruff clean.