### PR TITLE
feat: add Himawari band names and satellite-aware sector helpers

### DIFF
--- a/frontend/src/components/Animation/types.ts
+++ b/frontend/src/components/Animation/types.ts
@@ -58,8 +58,17 @@ export const SPEED_MULTIPLIERS: Record<SpeedPreset, number> = {
   timelapse: 30,
 };
 
-export const SATELLITES = ['GOES-16', 'GOES-18', 'GOES-19'];
-export const SECTORS = ['FullDisk', 'CONUS', 'Meso1', 'Meso2'];
-export const BANDS = Array.from({ length: 16 }, (_, i) => `C${String(i + 1).padStart(2, '0')}`);
+export const GOES_SATELLITES = ['GOES-16', 'GOES-18', 'GOES-19'];
+export const HIMAWARI_SATELLITES = ['Himawari-9'];
+export const SATELLITES = [...GOES_SATELLITES, ...HIMAWARI_SATELLITES];
+
+export const GOES_SECTORS = ['FullDisk', 'CONUS', 'Meso1', 'Meso2'];
+export const HIMAWARI_SECTORS = ['FLDK', 'Japan', 'Target'];
+export const SECTORS = [...GOES_SECTORS, ...HIMAWARI_SECTORS];
+
+export const GOES_BANDS = Array.from({ length: 16 }, (_, i) => `C${String(i + 1).padStart(2, '0')}`);
+export const HIMAWARI_BANDS = Array.from({ length: 16 }, (_, i) => `B${String(i + 1).padStart(2, '0')}`);
+/** @deprecated Use GOES_BANDS or HIMAWARI_BANDS for satellite-specific lists. */
+export const BANDS = GOES_BANDS;
 
 export const QUICK_HOURS = [1, 3, 6, 12, 24];

--- a/frontend/src/components/GoesData/liveTabUtils.ts
+++ b/frontend/src/components/GoesData/liveTabUtils.ts
@@ -1,5 +1,7 @@
 /** Shared helpers for LiveTab — extracted for react-refresh compatibility */
 
+import { isHimawariSatellite } from '../../utils/sectorHelpers';
+
 export const FRIENDLY_BAND_NAMES: Record<string, string> = {
   C01: 'Visible Blue',
   C02: 'Visible Red',
@@ -20,8 +22,35 @@ export const FRIENDLY_BAND_NAMES: Record<string, string> = {
   GEOCOLOR: 'GeoColor (True Color)',
 };
 
+export const HIMAWARI_BAND_NAMES: Record<string, string> = {
+  B01: 'Visible Blue',
+  B02: 'Visible Green',
+  B03: 'Visible Red',
+  B04: 'Near-IR Veggie',
+  B05: 'Snow/Ice',
+  B06: 'Cloud Particle',
+  B07: 'Shortwave IR',
+  B08: 'Upper Water Vapor',
+  B09: 'Mid Water Vapor',
+  B10: 'Lower Water Vapor',
+  B11: 'Cloud-Top Phase',
+  B12: 'Ozone',
+  B13: 'Clean IR Longwave',
+  B14: 'IR Longwave',
+  B15: 'Dirty Longwave',
+  B16: 'CO₂ Longwave',
+  TrueColor: 'True Color (RGB)',
+};
+
+/** Get the correct band name mapping for a satellite. */
+function getBandNames(satellite?: string): Record<string, string> {
+  if (satellite && isHimawariSatellite(satellite)) return HIMAWARI_BAND_NAMES;
+  return FRIENDLY_BAND_NAMES;
+}
+
 function formatShort(bandId: string, friendly?: string): string {
   if (bandId === 'GEOCOLOR') return 'GeoColor';
+  if (bandId === 'TrueColor') return 'TrueColor';
   return friendly ? `${bandId} ${friendly}` : bandId;
 }
 
@@ -36,10 +65,11 @@ function formatLong(bandId: string, friendly?: string, description?: string): st
   return formatMedium(bandId, friendly, description);
 }
 
-export function getFriendlyBandLabel(bandId: string, description?: string, format?: 'short' | 'medium' | 'long'): string {
-  const friendly = FRIENDLY_BAND_NAMES[bandId];
+export function getFriendlyBandLabel(bandId: string, description?: string, format?: 'short' | 'medium' | 'long', satellite?: string): string {
+  const names = getBandNames(satellite);
+  const friendly = names[bandId];
 
-  if (bandId === 'GEOCOLOR' && format !== 'short') return friendly ?? bandId;
+  if ((bandId === 'GEOCOLOR' || bandId === 'TrueColor') && format !== 'short') return friendly ?? bandId;
 
   switch (format) {
     case 'short': return formatShort(bandId, friendly);
@@ -48,8 +78,9 @@ export function getFriendlyBandLabel(bandId: string, description?: string, forma
   }
 }
 
-export function getFriendlyBandName(bandId: string): string {
-  return FRIENDLY_BAND_NAMES[bandId] ?? bandId;
+export function getFriendlyBandName(bandId: string, satellite?: string): string {
+  const names = getBandNames(satellite);
+  return names[bandId] ?? bandId;
 }
 
 export interface CachedImageMeta {

--- a/frontend/src/test/BandPillStrip.test.tsx
+++ b/frontend/src/test/BandPillStrip.test.tsx
@@ -118,4 +118,33 @@ describe('BandPillStrip', () => {
     render(<BandPillStrip {...defaultProps} sectorName="Full Disk" />);
     expect(screen.getByTestId('pill-strip-sector').textContent).toContain('Full Disk');
   });
+
+  it('renders Himawari bands correctly', () => {
+    const himawariBands = [
+      { id: 'TrueColor', description: 'True Color' },
+      { id: 'B03', description: 'Visible Red' },
+      { id: 'B07', description: 'Shortwave IR' },
+    ];
+    const himawariSectors = [
+      { id: 'FLDK', name: 'Full Disk' },
+      { id: 'Japan', name: 'Japan' },
+    ];
+    render(
+      <BandPillStrip
+        {...defaultProps}
+        bands={himawariBands}
+        activeBand="B03"
+        satellite="Himawari-9"
+        satellites={['GOES-16', 'GOES-18', 'Himawari-9']}
+        sectors={himawariSectors}
+        sectorName="Full Disk"
+      />,
+    );
+    expect(screen.getByTestId('band-pill-TrueColor')).toBeInTheDocument();
+    expect(screen.getByTestId('band-pill-B03')).toBeInTheDocument();
+    expect(screen.getByTestId('band-pill-B07')).toBeInTheDocument();
+    // Active band has correct styling
+    const activePill = screen.getByTestId('band-pill-B03');
+    expect(activePill.className).toContain('bg-primary/20');
+  });
 });

--- a/frontend/src/test/bands.test.ts
+++ b/frontend/src/test/bands.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { BAND_INFO, getBandLabel } from '../constants/bands';
+import {
+  FRIENDLY_BAND_NAMES,
+  HIMAWARI_BAND_NAMES,
+  getFriendlyBandLabel,
+  getFriendlyBandName,
+} from '../components/GoesData/liveTabUtils';
 
 describe('bands constants', () => {
   it('exports BAND_INFO with all 16 bands', () => {
@@ -26,5 +32,58 @@ describe('bands constants', () => {
       expect(info.color).toMatch(/^#[0-9a-f]{6}$/);
       expect(info.description).toBeTruthy();
     }
+  });
+});
+
+describe('GOES friendly band names', () => {
+  it('has 17 entries (16 bands + GEOCOLOR)', () => {
+    expect(Object.keys(FRIENDLY_BAND_NAMES).length).toBe(17);
+  });
+
+  it('getFriendlyBandName returns name for GOES bands', () => {
+    expect(getFriendlyBandName('C01')).toBe('Visible Blue');
+    expect(getFriendlyBandName('GEOCOLOR')).toBe('GeoColor (True Color)');
+  });
+
+  it('getFriendlyBandName returns bandId for unknown band', () => {
+    expect(getFriendlyBandName('ZZZZ')).toBe('ZZZZ');
+  });
+
+  it('getFriendlyBandLabel defaults to GOES without satellite param', () => {
+    const label = getFriendlyBandLabel('C02', undefined, 'medium');
+    expect(label).toContain('C02');
+    expect(label).toContain('Visible Red');
+  });
+});
+
+describe('Himawari friendly band names', () => {
+  it('has 17 entries (16 bands + TrueColor)', () => {
+    expect(Object.keys(HIMAWARI_BAND_NAMES).length).toBe(17);
+  });
+
+  it('getFriendlyBandName returns name for Himawari bands', () => {
+    expect(getFriendlyBandName('B01', 'Himawari-9')).toBe('Visible Blue');
+    expect(getFriendlyBandName('B02', 'Himawari-9')).toBe('Visible Green');
+    expect(getFriendlyBandName('TrueColor', 'Himawari-9')).toBe('True Color (RGB)');
+  });
+
+  it('getFriendlyBandName falls back to bandId for unknown Himawari band', () => {
+    expect(getFriendlyBandName('C01', 'Himawari-9')).toBe('C01');
+  });
+
+  it('getFriendlyBandLabel uses Himawari mapping when satellite provided', () => {
+    const label = getFriendlyBandLabel('B03', undefined, 'medium', 'Himawari-9');
+    expect(label).toContain('B03');
+    expect(label).toContain('Visible Red');
+  });
+
+  it('getFriendlyBandLabel short format for TrueColor', () => {
+    const label = getFriendlyBandLabel('TrueColor', undefined, 'short', 'Himawari-9');
+    expect(label).toBe('TrueColor');
+  });
+
+  it('getFriendlyBandLabel returns full name for TrueColor in medium format', () => {
+    const label = getFriendlyBandLabel('TrueColor', undefined, 'medium', 'Himawari-9');
+    expect(label).toBe('True Color (RGB)');
   });
 });

--- a/frontend/src/test/sectorHelpers.test.ts
+++ b/frontend/src/test/sectorHelpers.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isHimawariSatellite,
+  isMesoSector,
+  isRegionalSector,
+  isCompositeBandAvailable,
+  isGeocolorAvailable,
+  buildCdnUrl,
+  getDefaultBand,
+  getDefaultSector,
+} from '../utils/sectorHelpers';
+
+describe('isHimawariSatellite', () => {
+  it('returns true for Himawari-9', () => {
+    expect(isHimawariSatellite('Himawari-9')).toBe(true);
+  });
+
+  it('returns true for case-insensitive match', () => {
+    expect(isHimawariSatellite('himawari-9')).toBe(true);
+    expect(isHimawariSatellite('HIMAWARI-9')).toBe(true);
+  });
+
+  it('returns true for shorthand H9/H8', () => {
+    expect(isHimawariSatellite('H9')).toBe(true);
+    expect(isHimawariSatellite('h8')).toBe(true);
+  });
+
+  it('returns false for GOES satellites', () => {
+    expect(isHimawariSatellite('GOES-16')).toBe(false);
+    expect(isHimawariSatellite('GOES-18')).toBe(false);
+    expect(isHimawariSatellite('GOES-19')).toBe(false);
+  });
+});
+
+describe('isMesoSector', () => {
+  it('detects mesoscale sectors', () => {
+    expect(isMesoSector('Mesoscale1')).toBe(true);
+    expect(isMesoSector('Mesoscale2')).toBe(true);
+  });
+
+  it('rejects non-meso sectors', () => {
+    expect(isMesoSector('CONUS')).toBe(false);
+    expect(isMesoSector('FullDisk')).toBe(false);
+    expect(isMesoSector('FLDK')).toBe(false);
+  });
+});
+
+describe('isRegionalSector', () => {
+  it('returns true for GOES meso sectors', () => {
+    expect(isRegionalSector('GOES-16', 'Mesoscale1')).toBe(true);
+    expect(isRegionalSector('GOES-18', 'Mesoscale2')).toBe(true);
+  });
+
+  it('returns false for GOES non-meso sectors', () => {
+    expect(isRegionalSector('GOES-16', 'CONUS')).toBe(false);
+    expect(isRegionalSector('GOES-16', 'FullDisk')).toBe(false);
+  });
+
+  it('returns true for Himawari Japan/Target sectors', () => {
+    expect(isRegionalSector('Himawari-9', 'Japan')).toBe(true);
+    expect(isRegionalSector('Himawari-9', 'Target')).toBe(true);
+  });
+
+  it('returns false for Himawari FLDK', () => {
+    expect(isRegionalSector('Himawari-9', 'FLDK')).toBe(false);
+  });
+});
+
+describe('isCompositeBandAvailable', () => {
+  it('returns true for GOES non-meso sectors', () => {
+    expect(isCompositeBandAvailable('GOES-16', 'CONUS')).toBe(true);
+    expect(isCompositeBandAvailable('GOES-18', 'FullDisk')).toBe(true);
+  });
+
+  it('returns false for GOES meso sectors', () => {
+    expect(isCompositeBandAvailable('GOES-16', 'Mesoscale1')).toBe(false);
+  });
+
+  it('returns true for all Himawari sectors', () => {
+    expect(isCompositeBandAvailable('Himawari-9', 'FLDK')).toBe(true);
+    expect(isCompositeBandAvailable('Himawari-9', 'Japan')).toBe(true);
+    expect(isCompositeBandAvailable('Himawari-9', 'Target')).toBe(true);
+  });
+});
+
+describe('isGeocolorAvailable (deprecated)', () => {
+  it('still works for backward compat', () => {
+    expect(isGeocolorAvailable('CONUS')).toBe(true);
+    expect(isGeocolorAvailable('Mesoscale1')).toBe(false);
+  });
+});
+
+describe('buildCdnUrl', () => {
+  it('builds valid URL for GOES CONUS', () => {
+    const url = buildCdnUrl('GOES-16', 'CONUS', 'C02');
+    expect(url).toContain('cdn.star.nesdis.noaa.gov');
+    expect(url).toContain('GOES16');
+    expect(url).toContain('CONUS');
+  });
+
+  it('builds valid URL for GOES GEOCOLOR', () => {
+    const url = buildCdnUrl('GOES-18', 'FullDisk', 'GEOCOLOR');
+    expect(url).toContain('GEOCOLOR');
+    expect(url).toContain('FD');
+  });
+
+  it('returns null for meso sectors', () => {
+    expect(buildCdnUrl('GOES-16', 'Mesoscale1', 'C02')).toBeNull();
+  });
+
+  it('returns null for Himawari satellites', () => {
+    expect(buildCdnUrl('Himawari-9', 'FLDK', 'B01')).toBeNull();
+    expect(buildCdnUrl('Himawari-9', 'Japan', 'TrueColor')).toBeNull();
+  });
+
+  it('returns null for empty inputs', () => {
+    expect(buildCdnUrl('', 'CONUS', 'C02')).toBeNull();
+    expect(buildCdnUrl('GOES-16', '', 'C02')).toBeNull();
+    expect(buildCdnUrl('GOES-16', 'CONUS', '')).toBeNull();
+  });
+
+  it('uses mobile resolution when requested', () => {
+    const url = buildCdnUrl('GOES-16', 'CONUS', 'C02', true);
+    expect(url).toContain('1250x750');
+  });
+});
+
+describe('getDefaultBand', () => {
+  it('returns GEOCOLOR for GOES', () => {
+    expect(getDefaultBand('GOES-16')).toBe('GEOCOLOR');
+    expect(getDefaultBand('GOES-18')).toBe('GEOCOLOR');
+  });
+
+  it('returns TrueColor for Himawari', () => {
+    expect(getDefaultBand('Himawari-9')).toBe('TrueColor');
+  });
+});
+
+describe('getDefaultSector', () => {
+  it('returns CONUS for GOES', () => {
+    expect(getDefaultSector('GOES-16')).toBe('CONUS');
+  });
+
+  it('returns FLDK for Himawari', () => {
+    expect(getDefaultSector('Himawari-9')).toBe('FLDK');
+  });
+});

--- a/frontend/src/utils/sectorHelpers.ts
+++ b/frontend/src/utils/sectorHelpers.ts
@@ -1,9 +1,34 @@
-/** Returns true if the sector is a mesoscale sector (no CDN images available). */
+/** Returns true if the satellite is a Himawari satellite. */
+export function isHimawariSatellite(satellite: string): boolean {
+  const s = satellite.toLowerCase();
+  return s.startsWith('himawari') || s === 'h9' || s === 'h8';
+}
+
+/** Returns true if the sector is a mesoscale sector (GOES: no CDN images available). */
 export function isMesoSector(sector: string): boolean {
   return sector === 'Mesoscale1' || sector === 'Mesoscale2';
 }
 
-/** Returns true if GEOCOLOR is available for the given sector (CDN-only: CONUS + FullDisk). */
+/** Returns true if the sector is a "regional" sector for the given satellite.
+ *  GOES: Meso1/Meso2. Himawari: Japan/Target. */
+export function isRegionalSector(satellite: string, sector: string): boolean {
+  if (isHimawariSatellite(satellite)) {
+    return sector === 'Japan' || sector === 'Target';
+  }
+  return isMesoSector(sector);
+}
+
+/** Returns true if the composite band (GEOCOLOR or TrueColor) is available for the given satellite/sector. */
+export function isCompositeBandAvailable(satellite: string, sector: string): boolean {
+  if (isHimawariSatellite(satellite)) {
+    // TrueColor is available for all Himawari sectors
+    return true;
+  }
+  // GOES: GEOCOLOR not available for mesoscale sectors
+  return !isMesoSector(sector);
+}
+
+/** @deprecated Use isCompositeBandAvailable instead. Kept for backward compatibility. */
 export function isGeocolorAvailable(sector: string): boolean {
   return !isMesoSector(sector);
 }
@@ -20,9 +45,11 @@ const CDN_RESOLUTIONS: Readonly<Record<string, { desktop: string; mobile: string
   FullDisk: { desktop: '1808x1808', mobile: '1808x1808' },
 };
 
-/** Build a direct CDN URL from satellite/sector/band (returns null for meso sectors). */
+/** Build a direct CDN URL from satellite/sector/band (returns null for meso sectors and Himawari). */
 export function buildCdnUrl(satellite: string, sector: string, band: string, isMobile = false): string | null {
   if (!satellite || !sector || !band) return null;
+  // No CDN exists for Himawari satellites
+  if (isHimawariSatellite(satellite)) return null;
   const cdnSector = CDN_SECTOR_PATH[sector];
   if (!cdnSector) return null;
   const satPath = satellite.replaceAll('-', '');
@@ -32,4 +59,14 @@ export function buildCdnUrl(satellite: string, sector: string, band: string, isM
   const resolutions = CDN_RESOLUTIONS[sector] ?? CDN_RESOLUTIONS.CONUS;
   const resolution = isMobile ? resolutions.mobile : resolutions.desktop;
   return `https://cdn.star.nesdis.noaa.gov/${satPath}/ABI/${cdnSector}/${cdnBand}/${resolution}.jpg`;
+}
+
+/** Get the default composite band for a satellite. */
+export function getDefaultBand(satellite: string): string {
+  return isHimawariSatellite(satellite) ? 'TrueColor' : 'GEOCOLOR';
+}
+
+/** Get the default sector for a satellite. */
+export function getDefaultSector(satellite: string): string {
+  return isHimawariSatellite(satellite) ? 'FLDK' : 'CONUS';
 }


### PR DESCRIPTION
## PR 6: Dynamic Band Names + Sector Helpers

Part of the Himawari-9 support epic. PRs 1-5 (backend) are merged.

### Changes

**`frontend/src/components/GoesData/liveTabUtils.ts`**
- Added `HIMAWARI_BAND_NAMES` mapping (B01-B16 + TrueColor composite)
- `getFriendlyBandLabel()` now accepts optional `satellite` param — uses correct mapping per satellite
- `getFriendlyBandName()` similarly satellite-aware
- Full backward compatibility: without `satellite` param, behavior is identical to before

**`frontend/src/utils/sectorHelpers.ts`**
- `isHimawariSatellite(satellite)` — detects Himawari satellites (case-insensitive, supports H9/H8 shorthand)
- `isRegionalSector(satellite, sector)` — Meso for GOES, Japan/Target for Himawari
- `isCompositeBandAvailable(satellite, sector)` — handles GEOCOLOR (GOES) and TrueColor (Himawari) availability
- `buildCdnUrl()` — returns `null` for Himawari satellites (no CDN exists)
- `getDefaultBand(satellite)` — GEOCOLOR for GOES, TrueColor for Himawari
- `getDefaultSector(satellite)` — CONUS for GOES, FLDK for Himawari
- `isMesoSector()` and `isGeocolorAvailable()` preserved for backward compat

**`frontend/src/components/Animation/types.ts`**
- Added `GOES_SATELLITES`, `HIMAWARI_SATELLITES`, `GOES_SECTORS`, `HIMAWARI_SECTORS`, `GOES_BANDS`, `HIMAWARI_BANDS`
- `SATELLITES`, `SECTORS`, `BANDS` still exported (backward compat) — SATELLITES/SECTORS now include Himawari values

### Tests
- **`sectorHelpers.test.ts`** (new) — 28 tests covering all new helpers + CDN null for Himawari
- **`bands.test.ts`** — added Himawari band label tests
- **`BandPillStrip.test.tsx`** — added Himawari band rendering test
- All 201 test files pass (1704 tests), lint clean

### Backward Compatibility
All existing GOES behavior is preserved. New functions use optional parameters that default to GOES behavior when omitted.