### PR TITLE
feat: add Himawari satellite switching to Live Tab

### DIFF
--- a/HIMAWARI_PROGRESS.md
+++ b/HIMAWARI_PROGRESS.md
@@ -9,8 +9,8 @@
 | 3 | Himawari S3 catalog | ✅ Done | #308 | 2026-03-03 18:08 UTC |
 | 4 | Himawari fetch task | 🔨 Building | — | — |
 | 5 | True Color composite + scheduled fetch | ⏳ Waiting | — | — |
-| 6 | Frontend band names + sector helpers | ⏳ Waiting | — | — |
-| 7 | Live Tab satellite switching | ⏳ Waiting | — | — |
+| 6 | Frontend band names + sector helpers | ✅ Done | #311 | 2026-03-03 19:57 UTC |
+| 7 | Live Tab satellite switching | 🔨 Building | — | — |
 | 8 | Fetch, Animate, Browse, Presets | ⏳ Waiting | — | — |
 | 9 | API rename /api/goes/ → /api/satellite/ | ⏳ Waiting | — | — |
 | 10 | Auto-prune + disk management | ⏳ Waiting | — | — |

--- a/frontend/src/components/GoesData/BandPillStrip.tsx
+++ b/frontend/src/components/GoesData/BandPillStrip.tsx
@@ -194,11 +194,11 @@ export default function BandPillStrip({
               className={`shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-colors whitespace-nowrap ${pillClass}`}
               style={{ scrollSnapAlign: 'center' }}
               data-testid={`band-pill-${b.id}`}
-              aria-label={`Select band ${getFriendlyBandLabel(b.id, b.description, 'short')}${isActive ? ' (active)' : ''}${isDisabled ? ' (unavailable for mesoscale)' : ''}`}
+              aria-label={`Select band ${getFriendlyBandLabel(b.id, b.description, 'short', satellite)}${isActive ? ' (active)' : ''}${isDisabled ? ' (unavailable for this sector)' : ''}`}
               aria-pressed={isActive}
-              title={isDisabled ? 'Not available for mesoscale sectors' : undefined}
+              title={isDisabled ? 'Not available for this sector' : undefined}
             >
-              {getFriendlyBandLabel(b.id, b.description, 'short')}
+              {getFriendlyBandLabel(b.id, b.description, 'short', satellite)}
             </button>
           );
         })}

--- a/frontend/src/components/GoesData/LiveTab/LiveImageArea.tsx
+++ b/frontend/src/components/GoesData/LiveTab/LiveImageArea.tsx
@@ -14,7 +14,8 @@ import DesktopControlsBar from '../DesktopControlsBar';
 import MonitorSettingsPanel from '../MonitorSettingsPanel';
 import { RefreshCw } from 'lucide-react';
 import type { MonitorPreset } from '../monitorPresets';
-import { isMesoSector } from '../../../utils/sectorHelpers';
+import { isHimawariSatellite } from '../../../utils/sectorHelpers';
+import type { SectorOption, BandOption } from '../liveTabUtils';
 
 interface LiveImageAreaProps {
   readonly containerRef: RefObject<HTMLDivElement | null>;
@@ -68,6 +69,10 @@ interface LiveImageAreaProps {
   readonly setRefreshInterval: (v: number) => void;
   readonly setCompareMode: (v: boolean | ((v: boolean) => boolean)) => void;
   readonly products: Product | undefined;
+  readonly allSatellites: ReadonlyArray<string>;
+  readonly satelliteSectors: ReadonlyArray<SectorOption>;
+  readonly satelliteBands: ReadonlyArray<BandOption>;
+  readonly disabledBands: ReadonlyArray<string>;
   readonly setSatellite: (v: string) => void;
   readonly setSector: (v: string) => void;
   readonly setBand: (v: string) => void;
@@ -99,7 +104,8 @@ export function LiveImageArea(props: LiveImageAreaProps) {
     imageUrl, catalogImageUrl, localImageUrl, prevImageUrl,
     frame, prevFrame, monitoring, toggleMonitor,
     autoFetch, setAutoFetch, refreshInterval, setRefreshInterval,
-    setCompareMode, products, setSatellite, setSector, setBand,
+    setCompareMode, products, allSatellites, satelliteSectors, satelliteBands, disabledBands: disabledBandsProp,
+    setSatellite, setSector, setBand,
     refetch, resetCountdown, countdownDisplay, toggleFullscreen,
     startMonitor, stopMonitor, applyPreset,
     freshnessInfo, activeJobId, activeJob, fetchNow, lastFetchFailed,
@@ -139,7 +145,19 @@ export function LiveImageArea(props: LiveImageAreaProps) {
 
       <ImageErrorBoundary key={`${satellite}-${sector}-${band}`}>
         {(() => {
-          const isCdnUnavailable = !imageUrl && products?.sectors?.find((s) => s.id === sector)?.cdn_available === false && !isLoading;
+          const isHimawari = isHimawariSatellite(satellite);
+          const isCdnUnavailable = !imageUrl && (products?.sectors?.find((s) => s.id === sector)?.cdn_available === false || isHimawari) && !isLoading;
+          if (isCdnUnavailable && isHimawari) {
+            return (
+              <div className="flex flex-col items-center justify-center gap-4 text-center p-8 h-full" data-testid="himawari-no-preview">
+                <p className="text-white/70 text-sm">No CDN preview available for Himawari-9. Fetch data to view images.</p>
+                <button type="button" onClick={fetchNow} disabled={!!activeJobId}
+                  className="px-4 py-2 rounded-lg bg-primary/20 border border-primary/50 text-primary hover:bg-primary/30 transition-colors disabled:opacity-50">
+                  {activeJobId ? 'Fetching…' : 'Fetch Now'}
+                </button>
+              </div>
+            );
+          }
           if (isCdnUnavailable && isComposite) {
             return (
               <div className="flex flex-col items-center justify-center gap-4 text-center p-8" data-testid="geocolor-meso-message">
@@ -192,8 +210,8 @@ export function LiveImageArea(props: LiveImageAreaProps) {
             onRefreshIntervalChange={setRefreshInterval}
             compareMode={compareMode}
             onCompareModeChange={setCompareMode}
-            autoFetchDisabled={band === 'GEOCOLOR' || isMeso}
-            autoFetchDisabledReason={isMeso ? 'Auto-fetch not available for mesoscale sectors' : 'Auto-fetch not available for GeoColor — CDN images update automatically'}
+            autoFetchDisabled={isHimawariSatellite(satellite) || band === 'GEOCOLOR' || isMeso}
+            autoFetchDisabledReason={isHimawariSatellite(satellite) ? 'Auto-fetch not yet available for Himawari' : isMeso ? 'Auto-fetch not available for mesoscale sectors' : 'Auto-fetch not available for GeoColor — CDN images update automatically'}
           />
 
           <div className="col-span-2 sm:col-span-1 sm:ml-auto flex items-center gap-2 justify-end flex-shrink-0">
@@ -206,9 +224,9 @@ export function LiveImageArea(props: LiveImageAreaProps) {
               onStart={startMonitor}
               onStop={stopMonitor}
               onApplyPreset={applyPreset}
-              satellites={products?.satellites ?? []}
-              sectors={(products?.sectors ?? []).map((s) => ({ id: s.id, name: s.name }))}
-              bands={(products?.bands ?? []).map((b) => ({ id: b.id, description: b.description }))}
+              satellites={[...allSatellites]}
+              sectors={satelliteSectors.map((s) => ({ id: s.id, name: s.name }))}
+              bands={satelliteBands.map((b) => ({ id: b.id, description: b.description }))}
             />
             <button type="button" onClick={() => { refetch(); resetCountdown(); }}
               className="p-2 rounded-lg bg-white/10 backdrop-blur-md border border-white/20 text-white/80 hover:text-white hover:bg-white/20 transition-colors min-h-[44px] min-w-[44px] relative overflow-hidden"
@@ -246,8 +264,8 @@ export function LiveImageArea(props: LiveImageAreaProps) {
           onToggleMonitor={toggleMonitor}
           autoFetch={autoFetch}
           onAutoFetchChange={(v) => setAutoFetch(v)}
-          autoFetchDisabled={band === 'GEOCOLOR' || isMeso}
-          autoFetchDisabledReason={isMeso ? 'Auto-fetch not available for mesoscale sectors' : 'Auto-fetch not available for GeoColor — CDN images update automatically'}
+          autoFetchDisabled={isHimawariSatellite(satellite) || band === 'GEOCOLOR' || isMeso}
+          autoFetchDisabledReason={isHimawariSatellite(satellite) ? 'Auto-fetch not yet available for Himawari' : isMeso ? 'Auto-fetch not available for mesoscale sectors' : 'Auto-fetch not available for GeoColor — CDN images update automatically'}
         />
       </div>
 
@@ -275,18 +293,18 @@ export function LiveImageArea(props: LiveImageAreaProps) {
       {!isMobile && products?.bands && (
         <BandPillStrip
           variant="desktop"
-          bands={products.bands}
+          bands={satelliteBands}
           activeBand={band}
           onBandChange={setBand}
           satellite={satellite}
           sector={sector}
-          satellites={products?.satellites ?? []}
-          sectors={(products?.sectors ?? []).map((s) => ({ id: s.id, name: s.name }))}
+          satellites={[...allSatellites]}
+          sectors={satelliteSectors.map((s) => ({ id: s.id, name: s.name }))}
           onSatelliteChange={setSatellite}
           onSectorChange={setSector}
-          sectorName={products.sectors?.find((s) => s.id === sector)?.name}
+          sectorName={satelliteSectors.find((s) => s.id === sector)?.name}
           satelliteAvailability={products.satellite_availability}
-          disabledBands={isMesoSector(sector) ? ['GEOCOLOR'] : []}
+          disabledBands={[...disabledBandsProp]}
         />
       )}
     </div>

--- a/frontend/src/components/GoesData/LiveTab/LiveTab.tsx
+++ b/frontend/src/components/GoesData/LiveTab/LiveTab.tsx
@@ -13,8 +13,9 @@ import { useMonitorMode } from '../../../hooks/useMonitorMode';
 import { useLiveFetchJob } from '../../../hooks/useLiveFetchJob';
 import { useCountdownDisplay } from '../../../hooks/useCountdownDisplay';
 import { useSwipeBand } from '../../../hooks/useSwipeBand';
-import { isMesoSector } from '../../../utils/sectorHelpers';
+import { isMesoSector, isHimawariSatellite, getDefaultSector, getDefaultBand } from '../../../utils/sectorHelpers';
 import BandPillStrip from '../BandPillStrip';
+import { getSectorsForSatellite, getBandsForSatellite, isCompositeBand, getDisabledBands } from '../liveTabUtils';
 
 import { resolveImageUrls, computeFreshness, exitFullscreenSafe, enterFullscreenSafe, buildOuterClassName } from './liveHelpers';
 import { isNotFoundError, useZoomHint, useFullscreenSync, useLiveShortcuts } from './useLiveHooks';
@@ -117,17 +118,35 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
 
   useEffect(() => {
     if (!products?.bands?.length) return;
+    // Only validate band against API products for GOES satellites;
+    // Himawari bands come from client-side constants and won't be in the API response
+    if (isHimawariSatellite(satellite)) return;
     const bandExists = products.bands.some((b) => b.id === band);
     if (!bandExists) {
       setBand(products.bands[0].id);
     }
-  }, [products, band]);
+  }, [products, band, satellite]);
 
   useEffect(() => {
     if (isMesoSector(sector) && band === 'GEOCOLOR') {
       setBand('C02');
     }
   }, [sector, band]);
+
+  // When satellite changes (user action), reset sector and band to satellite-appropriate defaults.
+  // We track whether satellite was set via user action vs API init to avoid resetting on first load.
+  const satelliteInitialized = useRef(false);
+  useEffect(() => {
+    if (!satellite) return;
+    if (!satelliteInitialized.current) {
+      // First time satellite is set (from API init) — don't reset band/sector
+      satelliteInitialized.current = true;
+      return;
+    }
+    // User changed the satellite — reset to defaults for the new satellite
+    setSector(getDefaultSector(satellite));
+    setBand(getDefaultBand(satellite));
+  }, [satellite]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const { data: frame, isLoading, isError, refetch } = useQuery<LatestFrame>({
@@ -194,7 +213,21 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
   const isMeso = isMesoSector(sector);
   const { catalogImageUrl, localImageUrl, imageUrl, prevFrame, prevImageUrl } = resolveImageUrls(catalogLatest, frame, recentFrames, satellite, sector, band, isMobile);
   const freshnessInfo = computeFreshness(catalogLatest, frame);
-  const isComposite = band === 'GEOCOLOR';
+  const isComposite = isCompositeBand(band, satellite);
+
+  // Satellite-aware sectors and bands (prefer API data for GOES, use constants for Himawari)
+  const apiSectors = products?.sectors?.map((s) => ({ id: s.id, name: s.name }));
+  const apiBands = products?.bands?.map((b) => ({ id: b.id, description: b.description }));
+  const satelliteSectors = getSectorsForSatellite(satellite, apiSectors);
+  const satelliteBands = getBandsForSatellite(satellite, apiBands);
+  const disabledBands = getDisabledBands(satellite, sector);
+
+  // Merge Himawari-9 into the satellite list from products if not already present
+  const allSatellites = (() => {
+    const fromApi = products?.satellites ?? [];
+    if (fromApi.includes('Himawari-9')) return fromApi;
+    return [...fromApi, 'Himawari-9'];
+  })();
 
   return (
     <div ref={pullContainerRef} className={buildOuterClassName(zoom.isZoomed)}>
@@ -241,6 +274,10 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
         setRefreshInterval={setRefreshInterval}
         setCompareMode={setCompareMode}
         products={products}
+        allSatellites={allSatellites}
+        satelliteSectors={satelliteSectors}
+        satelliteBands={satelliteBands}
+        disabledBands={disabledBands}
         setSatellite={setSatellite}
         setSector={setSector}
         setBand={setBand}
@@ -262,18 +299,18 @@ export default function LiveTab({ onMonitorChange }: Readonly<LiveTabProps> = {}
 
       {isMobile && products?.bands && !zoom.isZoomed && (
         <BandPillStrip
-          bands={products.bands}
+          bands={satelliteBands}
           activeBand={band}
           onBandChange={setBand}
           satellite={satellite}
           sector={sector}
-          satellites={products?.satellites ?? []}
-          sectors={(products?.sectors ?? []).map((s) => ({ id: s.id, name: s.name }))}
+          satellites={allSatellites}
+          sectors={satelliteSectors}
           onSatelliteChange={setSatellite}
           onSectorChange={setSector}
-          sectorName={products.sectors?.find((s) => s.id === sector)?.name}
+          sectorName={satelliteSectors.find((s) => s.id === sector)?.name}
           satelliteAvailability={products.satellite_availability}
-          disabledBands={isMeso ? ['GEOCOLOR'] : []}
+          disabledBands={disabledBands}
         />
       )}
     </div>

--- a/frontend/src/components/GoesData/liveTabUtils.ts
+++ b/frontend/src/components/GoesData/liveTabUtils.ts
@@ -1,6 +1,6 @@
 /** Shared helpers for LiveTab — extracted for react-refresh compatibility */
 
-import { isHimawariSatellite } from '../../utils/sectorHelpers';
+import { isHimawariSatellite, isCompositeBandAvailable } from '../../utils/sectorHelpers';
 
 export const FRIENDLY_BAND_NAMES: Record<string, string> = {
   C01: 'Visible Blue',
@@ -156,4 +156,87 @@ export function getPrevBandIndex(currentIdx: number, length: number): number {
 export function getNextBandIndex(currentIdx: number, length: number): number {
   if (length === 0) return -1;
   return currentIdx < length - 1 ? currentIdx + 1 : 0;
+}
+
+/* ── Satellite-aware sectors & bands ────────────────────────────── */
+
+export interface SectorOption {
+  id: string;
+  name: string;
+}
+
+export interface BandOption {
+  id: string;
+  description: string;
+}
+
+const GOES_SECTORS: SectorOption[] = [
+  { id: 'FullDisk', name: 'Full Disk' },
+  { id: 'CONUS', name: 'CONUS' },
+  { id: 'Mesoscale1', name: 'Meso 1' },
+  { id: 'Mesoscale2', name: 'Meso 2' },
+];
+
+const HIMAWARI_SECTORS: SectorOption[] = [
+  { id: 'FLDK', name: 'Full Disk' },
+  { id: 'Japan', name: 'Japan' },
+  { id: 'Target', name: 'Target' },
+];
+
+function buildGoesBands(): BandOption[] {
+  return [
+    { id: 'GEOCOLOR', description: 'GeoColor (True Color Day, IR Night)' },
+    ...Array.from({ length: 16 }, (_, i) => {
+      const num = String(i + 1).padStart(2, '0');
+      const id = `C${num}`;
+      return { id, description: FRIENDLY_BAND_NAMES[id] ?? id };
+    }),
+  ];
+}
+
+function buildHimawariBands(): BandOption[] {
+  return [
+    { id: 'TrueColor', description: 'True Color (RGB)' },
+    ...Array.from({ length: 16 }, (_, i) => {
+      const num = String(i + 1).padStart(2, '0');
+      const id = `B${num}`;
+      return { id, description: HIMAWARI_BAND_NAMES[id] ?? id };
+    }),
+  ];
+}
+
+/** Return sectors relevant to the selected satellite.
+ *  For GOES: uses API-provided sectors if available, falls back to defaults.
+ *  For Himawari: always uses client-side constants (API may not have them). */
+export function getSectorsForSatellite(satellite: string, apiSectors?: ReadonlyArray<SectorOption>): SectorOption[] {
+  if (isHimawariSatellite(satellite)) return HIMAWARI_SECTORS;
+  return apiSectors && apiSectors.length > 0 ? [...apiSectors] : GOES_SECTORS;
+}
+
+/** Return bands relevant to the selected satellite.
+ *  For GOES: uses API-provided bands if available, falls back to defaults.
+ *  For Himawari: always uses client-side constants. */
+export function getBandsForSatellite(satellite: string, apiBands?: ReadonlyArray<BandOption>): BandOption[] {
+  if (isHimawariSatellite(satellite)) return buildHimawariBands();
+  return apiBands && apiBands.length > 0 ? [...apiBands] : buildGoesBands();
+}
+
+/** Get the composite band id for a satellite (GEOCOLOR or TrueColor). */
+export function getCompositeBand(satellite: string): string {
+  return isHimawariSatellite(satellite) ? 'TrueColor' : 'GEOCOLOR';
+}
+
+/** Check if a given band is the composite band for the satellite. */
+export function isCompositeBand(band: string, satellite: string): boolean {
+  if (isHimawariSatellite(satellite)) return band === 'TrueColor';
+  return band === 'GEOCOLOR';
+}
+
+/** Get disabled bands for a given satellite/sector combination. */
+export function getDisabledBands(satellite: string, sector: string): string[] {
+  const compositeBand = getCompositeBand(satellite);
+  if (!isCompositeBandAvailable(satellite, sector)) {
+    return [compositeBand];
+  }
+  return [];
 }

--- a/frontend/src/test/LiveTabHimawari.test.tsx
+++ b/frontend/src/test/LiveTabHimawari.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: vi.fn(() => Promise.resolve({ data: {} })),
+    post: vi.fn(() => Promise.resolve({ data: { job_id: 'job-1' } })),
+  },
+}));
+
+import LiveTab from '../components/GoesData/LiveTab';
+import api from '../api/client';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedApi = api as any;
+
+const PRODUCTS = {
+  satellites: ['GOES-16', 'GOES-18', 'GOES-19'],
+  sectors: [
+    { id: 'CONUS', name: 'CONUS', product: 'ABI-L2-CMIPF' },
+    { id: 'FullDisk', name: 'Full Disk', product: 'ABI-L2-CMIPF' },
+    { id: 'Mesoscale1', name: 'Meso 1', product: 'ABI-L2-CMIPM' },
+    { id: 'Mesoscale2', name: 'Meso 2', product: 'ABI-L2-CMIPM' },
+  ],
+  bands: [
+    { id: 'GEOCOLOR', description: 'GeoColor (True Color Day, IR Night)' },
+    { id: 'C01', description: 'Blue (0.47µm)' },
+    { id: 'C02', description: 'Red (0.64µm)' },
+  ],
+  default_satellite: 'GOES-16',
+};
+
+const FRAME = {
+  id: '1', satellite: 'GOES-16', sector: 'CONUS', band: 'GEOCOLOR',
+  capture_time: new Date(Date.now() - 600000).toISOString(),
+  file_size: 1024, width: 5424, height: 3000,
+  image_url: '/api/goes/frames/test-id/image',
+  thumbnail_url: '/api/goes/frames/test-id/thumbnail',
+};
+
+function renderLiveTab() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <LiveTab />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockedApi.get.mockImplementation((url: string) => {
+    if (url === '/goes/products') return Promise.resolve({ data: PRODUCTS });
+    if (url.startsWith('/goes/latest')) return Promise.resolve({ data: FRAME });
+    if (url.startsWith('/goes/catalog/latest')) return Promise.resolve({ data: null });
+    return Promise.resolve({ data: {} });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LiveTab - Himawari satellite switching', () => {
+  it('satellite dropdown shows all 4 options including Himawari-9', async () => {
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-satellite')).toBeInTheDocument());
+
+    // Expand satellite options
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('satellite-option-GOES-16')).toBeInTheDocument();
+      expect(screen.getByTestId('satellite-option-GOES-18')).toBeInTheDocument();
+      expect(screen.getByTestId('satellite-option-GOES-19')).toBeInTheDocument();
+      expect(screen.getByTestId('satellite-option-Himawari-9')).toBeInTheDocument();
+    });
+  });
+
+  it('selecting Himawari-9 resets sector to FLDK and band to TrueColor', async () => {
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-satellite')).toBeInTheDocument());
+
+    // Expand satellite options and select Himawari-9
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+    await waitFor(() => expect(screen.getByTestId('satellite-option-Himawari-9')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('satellite-option-Himawari-9'));
+
+    // Verify status pill shows Himawari-9 and TrueColor
+    await waitFor(() => {
+      const pill = screen.getByTestId('status-pill');
+      expect(pill.textContent).toContain('Himawari-9');
+      expect(pill.textContent).toContain('TrueColor');
+    });
+  });
+
+  it('Himawari sector options are FLDK, Japan, Target', async () => {
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-satellite')).toBeInTheDocument());
+
+    // Switch to Himawari-9
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+    await waitFor(() => expect(screen.getByTestId('satellite-option-Himawari-9')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('satellite-option-Himawari-9'));
+
+    // Wait for switch to complete
+    await waitFor(() => {
+      const pill = screen.getByTestId('status-pill');
+      expect(pill.textContent).toContain('Himawari-9');
+    });
+
+    // Expand sector options
+    fireEvent.click(screen.getByTestId('pill-strip-sector'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sector-option-FLDK')).toBeInTheDocument();
+      expect(screen.getByTestId('sector-option-Japan')).toBeInTheDocument();
+      expect(screen.getByTestId('sector-option-Target')).toBeInTheDocument();
+    });
+
+    // GOES sectors should NOT be present
+    expect(screen.queryByTestId('sector-option-CONUS')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sector-option-FullDisk')).not.toBeInTheDocument();
+  });
+
+  it('GOES sector options are FullDisk, CONUS, Meso1, Meso2', async () => {
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-sector')).toBeInTheDocument());
+
+    // Expand sector options (should show GOES sectors by default)
+    fireEvent.click(screen.getByTestId('pill-strip-sector'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sector-option-CONUS')).toBeInTheDocument();
+      expect(screen.getByTestId('sector-option-FullDisk')).toBeInTheDocument();
+      expect(screen.getByTestId('sector-option-Mesoscale1')).toBeInTheDocument();
+      expect(screen.getByTestId('sector-option-Mesoscale2')).toBeInTheDocument();
+    });
+  });
+
+  it('Himawari band options include TrueColor and B01-B16', async () => {
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-satellite')).toBeInTheDocument());
+
+    // Switch to Himawari-9
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+    await waitFor(() => expect(screen.getByTestId('satellite-option-Himawari-9')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('satellite-option-Himawari-9'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('band-pill-TrueColor')).toBeInTheDocument();
+      expect(screen.getByTestId('band-pill-B01')).toBeInTheDocument();
+      expect(screen.getByTestId('band-pill-B16')).toBeInTheDocument();
+    });
+
+    // GOES bands should NOT be present
+    expect(screen.queryByTestId('band-pill-GEOCOLOR')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('band-pill-C01')).not.toBeInTheDocument();
+  });
+
+  it('switching back to GOES resets sector to CONUS and band to GEOCOLOR', async () => {
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-satellite')).toBeInTheDocument());
+
+    // Switch to Himawari-9
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+    await waitFor(() => expect(screen.getByTestId('satellite-option-Himawari-9')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('satellite-option-Himawari-9'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status-pill').textContent).toContain('Himawari-9');
+    });
+
+    // Switch back to GOES-18
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+    await waitFor(() => expect(screen.getByTestId('satellite-option-GOES-18')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('satellite-option-GOES-18'));
+
+    // Should show GOES defaults
+    await waitFor(() => {
+      const pill = screen.getByTestId('status-pill');
+      expect(pill.textContent).toContain('GOES-18');
+      expect(pill.textContent).toContain('GEOCOLOR');
+    });
+
+    // GOES bands should be visible
+    await waitFor(() => {
+      expect(screen.getByTestId('band-pill-GEOCOLOR')).toBeInTheDocument();
+    });
+  });
+
+  it('CDN preview is not available for Himawari (shows no-preview message)', async () => {
+    // No local frame for Himawari
+    mockedApi.get.mockImplementation((url: string) => {
+      if (url === '/goes/products') return Promise.resolve({ data: PRODUCTS });
+      if (url.startsWith('/goes/latest')) {
+        const axiosError = Object.assign(new Error('Not found'), {
+          isAxiosError: true,
+          response: { status: 404 },
+        });
+        return Promise.reject(axiosError);
+      }
+      if (url.startsWith('/goes/catalog/latest')) return Promise.resolve({ data: null });
+      return Promise.resolve({ data: {} });
+    });
+
+    renderLiveTab();
+    await waitFor(() => expect(screen.getByTestId('pill-strip-satellite')).toBeInTheDocument());
+
+    // Switch to Himawari-9
+    fireEvent.click(screen.getByTestId('pill-strip-satellite'));
+    await waitFor(() => expect(screen.getByTestId('satellite-option-Himawari-9')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('satellite-option-Himawari-9'));
+
+    // Should show "no preview available" for Himawari
+    await waitFor(() => {
+      expect(screen.getByTestId('himawari-no-preview')).toBeInTheDocument();
+    });
+  });
+
+  it('existing GOES behavior is preserved', async () => {
+    renderLiveTab();
+
+    // Default satellite should be GOES-16
+    await waitFor(() => {
+      const pill = screen.getByTestId('status-pill');
+      expect(pill.textContent).toContain('GOES-16');
+      expect(pill.textContent).toContain('GEOCOLOR');
+    });
+
+    // Band pills should show GOES bands
+    await waitFor(() => {
+      expect(screen.getByTestId('band-pill-GEOCOLOR')).toBeInTheDocument();
+      expect(screen.getByTestId('band-pill-C01')).toBeInTheDocument();
+      expect(screen.getByTestId('band-pill-C02')).toBeInTheDocument();
+    });
+
+    // Switching bands should work
+    fireEvent.click(screen.getByTestId('band-pill-C02'));
+    await waitFor(() => {
+      expect(screen.getByTestId('band-pill-C02').getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Himawari-9 satellite support to the Live Tab, enabling users to switch between GOES and Himawari satellites with appropriate sector and band options.

## Changes

### LiveTab.tsx
- Added Himawari-9 to the satellite dropdown (merged into API-provided satellite list)
- Satellite-aware sector/band reset: switching satellites auto-sets defaults (GOES→CONUS/GEOCOLOR, Himawari→FLDK/TrueColor)
- Fixed satellite init effect: uses `satelliteInitialized` ref to distinguish API init from user-initiated satellite changes
- Band validation effect is satellite-aware (skips API band check for Himawari)
- Uses `isCompositeBand()` instead of hardcoded `band === 'GEOCOLOR'` check

### LiveImageArea.tsx
- Accepts new props: `allSatellites`, `satelliteSectors`, `satelliteBands`, `disabledBands`
- BandPillStrip and MonitorSettingsPanel use satellite-aware lists
- Himawari-specific CDN unavailable message (`himawari-no-preview` test ID) with Fetch button
- Auto-fetch disabled for Himawari satellites

### BandPillStrip.tsx
- Passes `satellite` to `getFriendlyBandLabel()` for correct Himawari band names (B01-B16 vs C01-C16)

### liveTabUtils.ts
New satellite-aware helpers:
- `getSectorsForSatellite(satellite, apiSectors?)` — returns GOES sectors from API or Himawari constants
- `getBandsForSatellite(satellite, apiBands?)` — returns GOES bands from API or Himawari constants
- `isCompositeBand(band, satellite)` — checks GEOCOLOR (GOES) or TrueColor (Himawari)
- `getCompositeBand(satellite)` — returns the composite band ID
- `getDisabledBands(satellite, sector)` — returns bands disabled for a satellite/sector combo

## Sector/Band Mapping

| | GOES | Himawari |
|---|---|---|
| **Sectors** | FullDisk, CONUS, Meso1, Meso2 | FLDK, Japan, Target |
| **Bands** | GEOCOLOR, C01-C16 | TrueColor, B01-B16 |
| **Default sector** | CONUS | FLDK |
| **Default band** | GEOCOLOR | TrueColor |
| **CDN preview** | ✅ Available | ❌ No CDN (show Fetch button) |

## Tests

8 new tests in `LiveTabHimawari.test.tsx`:
- Satellite dropdown shows all 4 options (GOES-16, GOES-18, GOES-19, Himawari-9)
- Selecting Himawari → sector resets to FLDK, band resets to TrueColor
- Himawari sector options: FLDK, Japan, Target
- GOES sector options: FullDisk, CONUS, Meso1, Meso2
- Himawari band options: TrueColor, B01-B16
- Switching back to GOES → CONUS/GEOCOLOR defaults
- CDN preview hidden for Himawari
- Existing GOES behavior preserved

**All 1712 tests pass** (1704 existing + 8 new). Zero lint errors.

## Part of Himawari-9 Implementation (PR 7)
Uses helpers from PR 6: `isHimawariSatellite()`, `getDefaultBand()`, `getDefaultSector()`, `buildCdnUrl()`, `HIMAWARI_BAND_NAMES`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Himawari-9 satellite support to the Live Tab with satellite-specific sector and band options.
  * Satellite selection now adapts available sectors and bands dynamically based on the selected satellite.
  * Enhanced band accessibility labeling and messaging to include satellite context.
  * Improved unavailability messaging for sectors and bands based on current selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->