### PR TITLE
chore(deps): upgrade redis from 6.4.0 to 7.3.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,7 +32,7 @@ matplotlib>=3.8.0
 
 # Task Queue
 celery[redis]==5.6.2
-redis==6.4.0
+redis==7.3.0
 
 # Logging
 python-json-logger==4.0.0


### PR DESCRIPTION
## Summary
- Upgrades **redis-py** from 6.4.0 to 7.3.0
- Gains: Python 3.14 support, deadlock prevention (RLock), new commands (MSETEX, CAS/CAD), improved type annotations
- No breaking changes affect this codebase (no use of EvictionPolicy, parse_list_to_dict, or sync context managers on async RedisCluster)

Supersedes #328.

## Test plan
- [x] Backend tests: 2272 passed, 50 skipped, 0 failures
- [x] Core tests: 368 passed, 15 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis dependency to version 7.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->