### PR TITLE
test(frontend): adopt MSW + raise coverage gate to 70%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,11 +304,24 @@ jobs:
         working-directory: frontend
         run: npx prettier --check .
 
-      - name: Unit Tests with coverage
+      # Shard 1 runs the FULL suite with coverage so the 70% threshold
+      # defined in `vite.config.ts` is enforced against combined
+      # coverage. Shard 2 runs only its half without coverage as a
+      # parallel-execution sanity check. Sharded threshold checks would
+      # be misleading because a single shard only exercises ~half the
+      # codebase.
+      - name: Unit Tests with coverage (full suite, gate)
+        if: matrix.shard == 1
         working-directory: frontend
-        run: npx vitest run --coverage --shard=${{ matrix.shard }}/2
+        run: npx vitest run --coverage
+
+      - name: Unit Tests (shard 2, no coverage)
+        if: matrix.shard == 2
+        working-directory: frontend
+        run: npx vitest run --shard=${{ matrix.shard }}/2
 
       - name: Upload coverage artifact
+        if: matrix.shard == 1
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: frontend-coverage-shard${{ matrix.shard }}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-react-refresh": "^0.5.0",
         "globals": "^17.3.0",
         "happy-dom": "^20.8.9",
+        "msw": "^2.13.2",
         "openapi-typescript": "^7.13.0",
         "rollup-plugin-visualizer": "^7.0.1",
         "semantic-release": "^25.0.3",
@@ -966,6 +967,109 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1009,6 +1113,24 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1186,6 +1308,31 @@
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
@@ -2722,6 +2869,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
@@ -3863,6 +4017,16 @@
       },
       "optionalDependencies": {
         "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -5698,6 +5862,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -5838,6 +6012,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -6359,6 +6540,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7538,6 +7726,77 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.2.tgz",
+      "integrity": "sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -9779,6 +10038,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -10017,6 +10283,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10636,6 +10909,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
@@ -11599,6 +11879,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -11630,6 +11920,13 @@
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -12052,6 +12349,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12063,6 +12380,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/traverse": {
@@ -12355,6 +12685,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -12940,6 +13280,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.3.0",
     "happy-dom": "^20.8.9",
+    "msw": "^2.13.2",
     "openapi-typescript": "^7.13.0",
     "rollup-plugin-visualizer": "^7.0.1",
     "semantic-release": "^25.0.3",

--- a/frontend/src/test/BrowseTabDefensive.test.tsx
+++ b/frontend/src/test/BrowseTabDefensive.test.tsx
@@ -1,55 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse, delay } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-    put: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
 vi.mock('../hooks/useDebounce', () => ({ useDebounce: (val: string) => val }));
 
 import BrowseTab from '../components/GoesData/BrowseTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
-
-function setupDefaultMocks() {
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url.includes('/satellite/frames')) {
-      return Promise.resolve({ data: { items: [], total: 0, page: 1, per_page: 24, pages: 0 } });
-    }
-    if (url === '/satellite/products')
-      return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-    if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-    if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-    return Promise.resolve({ data: {} });
-  });
-}
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  setupDefaultMocks();
-});
+const server = setupMswServer();
 
 describe('BrowseTab - Defensive Scenarios', () => {
   // --- API returns unexpected shapes ---
 
   it('handles frames API returning raw array instead of paginated object', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames')) return Promise.resolve({ data: [] });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/frames', () => HttpResponse.json([])));
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -57,14 +23,7 @@ describe('BrowseTab - Defensive Scenarios', () => {
   });
 
   it('handles frames API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames')) return Promise.resolve({ data: null });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/frames', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -72,14 +31,7 @@ describe('BrowseTab - Defensive Scenarios', () => {
   });
 
   it('handles products API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames'))
-        return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 50 } });
-      if (url === '/satellite/products') return Promise.resolve({ data: null });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/products', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -87,18 +39,14 @@ describe('BrowseTab - Defensive Scenarios', () => {
   });
 
   it('handles tags API returning paginated object instead of array', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames'))
-        return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 50 } });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags')
-        return Promise.resolve({
-          data: { items: [{ id: '1', name: 'test', color: '#ff0000' }], total: 1 },
-        });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/tags', () =>
+        HttpResponse.json({
+          items: [{ id: '1', name: 'test', color: '#ff0000' }],
+          total: 1,
+        }),
+      ),
+    );
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -106,18 +54,14 @@ describe('BrowseTab - Defensive Scenarios', () => {
   });
 
   it('handles collections API returning paginated object instead of array', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames'))
-        return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 50 } });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections')
-        return Promise.resolve({
-          data: { items: [{ id: '1', name: 'My Col', frame_count: 5 }], total: 1 },
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () =>
+        HttpResponse.json({
+          items: [{ id: '1', name: 'My Col', frame_count: 5 }],
+          total: 1,
+        }),
+      ),
+    );
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -143,7 +87,12 @@ describe('BrowseTab - Defensive Scenarios', () => {
   // --- Loading states ---
 
   it('shows skeleton loading cards while fetching', () => {
-    mockedApi.get.mockReturnValue(new Promise(() => {}));
+    server.use(
+      http.get('*/api/satellite/frames', async () => {
+        await delay('infinite');
+        return HttpResponse.json({ items: [], total: 0, page: 1, limit: 50 });
+      }),
+    );
     renderWithProviders(<BrowseTab />);
     // Skeleton divs with animate-pulse should be present
     const pulseElements = document.querySelectorAll('.animate-pulse');
@@ -153,46 +102,40 @@ describe('BrowseTab - Defensive Scenarios', () => {
   // --- With data ---
 
   it('renders frames when data exists', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames')) {
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                id: '1',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                band: 'C02',
-                capture_time: '2024-06-01T12:00:00',
-                file_path: '/tmp/test.nc',
-                file_size: 1024,
-                width: 5424,
-                height: 3000,
-                thumbnail_path: null,
-                image_url: '/api/satellite/frames/test-id/image',
-                thumbnail_url: '/api/satellite/frames/test-id/thumbnail',
-                tags: [],
-                collections: [],
-              },
-            ],
-            total: 1,
-            page: 1,
-            limit: 50,
-          },
-        });
-      }
-      if (url === '/satellite/products')
-        return Promise.resolve({
-          data: {
-            satellites: ['GOES-16'],
-            bands: [{ id: 'C02', description: 'Red' }],
-            sectors: [{ id: 'CONUS', name: 'CONUS', product: 'x' }],
-          },
-        });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/frames', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: '1',
+              satellite: 'GOES-16',
+              sector: 'CONUS',
+              band: 'C02',
+              capture_time: '2024-06-01T12:00:00',
+              file_path: '/tmp/test.nc',
+              file_size: 1024,
+              width: 5424,
+              height: 3000,
+              thumbnail_path: null,
+              image_url: '/api/satellite/frames/test-id/image',
+              thumbnail_url: '/api/satellite/frames/test-id/thumbnail',
+              tags: [],
+              collections: [],
+            },
+          ],
+          total: 1,
+          page: 1,
+          limit: 50,
+        }),
+      ),
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({
+          satellites: ['GOES-16'],
+          bands: [{ id: 'C02', description: 'Red' }],
+          sectors: [{ id: 'CONUS', name: 'CONUS', product: 'x' }],
+        }),
+      ),
+    );
     renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       // The frames count text appears in the toolbar
@@ -211,38 +154,31 @@ describe('BrowseTab - Defensive Scenarios', () => {
   });
 
   it('renders Load More button when multiple pages exist', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames')) {
-        return Promise.resolve({
-          data: {
-            items: Array.from({ length: 50 }, (_, i) => ({
-              id: `${i}`,
-              satellite: 'GOES-16',
-              sector: 'CONUS',
-              band: 'C02',
-              capture_time: '2024-06-01T12:00:00',
-              file_path: '/tmp/test.nc',
-              file_size: 1024,
-              width: null,
-              height: null,
-              thumbnail_path: null,
-              image_url: '/api/satellite/frames/test-id/image',
-              thumbnail_url: '/api/satellite/frames/test-id/thumbnail',
-              tags: [],
-              collections: [],
-            })),
-            total: 200,
-            page: 1,
-            limit: 50,
-          },
-        });
-      }
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/frames', () =>
+        HttpResponse.json({
+          items: Array.from({ length: 50 }, (_, i) => ({
+            id: `${i}`,
+            satellite: 'GOES-16',
+            sector: 'CONUS',
+            band: 'C02',
+            capture_time: '2024-06-01T12:00:00',
+            file_path: '/tmp/test.nc',
+            file_size: 1024,
+            width: null,
+            height: null,
+            thumbnail_path: null,
+            image_url: '/api/satellite/frames/test-id/image',
+            thumbnail_url: '/api/satellite/frames/test-id/thumbnail',
+            tags: [],
+            collections: [],
+          })),
+          total: 200,
+          page: 1,
+          limit: 50,
+        }),
+      ),
+    );
     renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(screen.getByText('Load More')).toBeInTheDocument();
@@ -264,7 +200,12 @@ describe('BrowseTab - Defensive Scenarios', () => {
   // --- Error state ---
 
   it('handles all APIs failing simultaneously', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Server down'));
+    server.use(
+      http.get('*/api/satellite/frames', () => HttpResponse.error()),
+      http.get('*/api/satellite/products', () => HttpResponse.error()),
+      http.get('*/api/satellite/tags', () => HttpResponse.error()),
+      http.get('*/api/satellite/collections', () => HttpResponse.error()),
+    );
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -274,40 +215,33 @@ describe('BrowseTab - Defensive Scenarios', () => {
   // --- Frames with null/undefined fields ---
 
   it('handles frames with null width/height/thumbnail', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames')) {
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                id: '1',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                band: 'C02',
-                capture_time: '2024-06-01T12:00:00',
-                file_path: '/tmp/test.nc',
-                file_size: 0,
-                width: null,
-                height: null,
-                thumbnail_path: null,
-                image_url: '/api/satellite/frames/test-id/image',
-                thumbnail_url: '/api/satellite/frames/test-id/thumbnail',
-                tags: [],
-                collections: [],
-              },
-            ],
-            total: 1,
-            page: 1,
-            limit: 50,
-          },
-        });
-      }
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/frames', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: '1',
+              satellite: 'GOES-16',
+              sector: 'CONUS',
+              band: 'C02',
+              capture_time: '2024-06-01T12:00:00',
+              file_path: '/tmp/test.nc',
+              file_size: 0,
+              width: null,
+              height: null,
+              thumbnail_path: null,
+              image_url: '/api/satellite/frames/test-id/image',
+              thumbnail_url: '/api/satellite/frames/test-id/thumbnail',
+              tags: [],
+              collections: [],
+            },
+          ],
+          total: 1,
+          page: 1,
+          limit: 50,
+        }),
+      ),
+    );
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -327,16 +261,11 @@ describe('BrowseTab - Defensive Scenarios', () => {
 
   // --- framesData.limit being 0 (division by zero for totalPages) ---
   it('handles framesData.limit being 0', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url.includes('/satellite/frames')) {
-        return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 0 } });
-      }
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], bands: [], sectors: [] } });
-      if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-      if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/frames', () =>
+        HttpResponse.json({ items: [], total: 0, page: 1, limit: 0 }),
+      ),
+    );
     const { container } = renderWithProviders(<BrowseTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);

--- a/frontend/src/test/CleanupTab.test.tsx
+++ b/frontend/src/test/CleanupTab.test.tsx
@@ -1,36 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-    put: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 import CleanupTab from '../components/GoesData/CleanupTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
+const server = setupMswServer();
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/cleanup-rules') return Promise.resolve({ data: [] });
-    if (url === '/satellite/frames/stats') {
-      return Promise.resolve({
-        data: { total_frames: 100, total_size_bytes: 1024000, by_satellite: {}, by_band: {} },
-      });
-    }
-    if (url === '/satellite/cleanup/preview') {
-      return Promise.resolve({ data: { frame_count: 0, total_size_bytes: 0, frames: [] } });
-    }
-    return Promise.resolve({ data: {} });
-  });
+  // Most tests in this file expect non-zero stats.
+  server.use(
+    http.get('*/api/satellite/frames/stats', () =>
+      HttpResponse.json({
+        total_frames: 100,
+        total_size_bytes: 1024000,
+        by_satellite: {},
+        by_band: {},
+      }),
+    ),
+  );
 });
 
 describe('CleanupTab', () => {
@@ -49,29 +38,21 @@ describe('CleanupTab', () => {
   });
 
   it('renders rules list when data exists', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/cleanup-rules') {
-        return Promise.resolve({
-          data: [
-            {
-              id: '1',
-              name: 'Age Rule',
-              rule_type: 'max_age_days',
-              value: 30,
-              protect_collections: true,
-              is_active: true,
-              created_at: '2024-06-01',
-            },
-          ],
-        });
-      }
-      if (url === '/satellite/frames/stats') {
-        return Promise.resolve({
-          data: { total_frames: 0, total_size_bytes: 0, by_satellite: {}, by_band: {} },
-        });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/cleanup-rules', () =>
+        HttpResponse.json([
+          {
+            id: '1',
+            name: 'Age Rule',
+            rule_type: 'max_age_days',
+            value: 30,
+            protect_collections: true,
+            is_active: true,
+            created_at: '2024-06-01',
+          },
+        ]),
+      ),
+    );
     renderWithProviders(<CleanupTab />);
     await waitFor(() => {
       expect(screen.getByText('Age Rule')).toBeInTheDocument();

--- a/frontend/src/test/CleanupTabDefensive.test.tsx
+++ b/frontend/src/test/CleanupTabDefensive.test.tsx
@@ -1,35 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-    put: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
 
 import CleanupTab from '../components/GoesData/CleanupTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/cleanup-rules') return Promise.resolve({ data: [] });
-    if (url === '/satellite/frames/stats')
-      return Promise.resolve({
-        data: { total_frames: 0, total_size_bytes: 0, by_satellite: {}, by_band: {} },
-      });
-    return Promise.resolve({ data: {} });
-  });
-});
+const server = setupMswServer();
 
 describe('CleanupTab - Defensive Scenarios', () => {
   it('renders without crashing with empty data', async () => {
@@ -40,14 +19,7 @@ describe('CleanupTab - Defensive Scenarios', () => {
   });
 
   it('handles cleanup-rules API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/cleanup-rules') return Promise.resolve({ data: null });
-      if (url === '/satellite/frames/stats')
-        return Promise.resolve({
-          data: { total_frames: 0, total_size_bytes: 0, by_satellite: {}, by_band: {} },
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/cleanup-rules', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<CleanupTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -55,11 +27,7 @@ describe('CleanupTab - Defensive Scenarios', () => {
   });
 
   it('handles stats API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/cleanup-rules') return Promise.resolve({ data: [] });
-      if (url === '/satellite/frames/stats') return Promise.resolve({ data: null });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/frames/stats', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<CleanupTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -67,7 +35,11 @@ describe('CleanupTab - Defensive Scenarios', () => {
   });
 
   it('handles all APIs failing', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Network error'));
+    server.use(
+      http.get('*/api/satellite/cleanup-rules', () => HttpResponse.error()),
+      http.get('*/api/satellite/frames/stats', () => HttpResponse.error()),
+      http.get('*/api/satellite/cleanup/stats', () => HttpResponse.error()),
+    );
     const { container } = renderWithProviders(<CleanupTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -75,14 +47,7 @@ describe('CleanupTab - Defensive Scenarios', () => {
   });
 
   it('handles stats with zero values (no division errors)', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/cleanup-rules') return Promise.resolve({ data: [] });
-      if (url === '/satellite/frames/stats')
-        return Promise.resolve({
-          data: { total_frames: 0, total_size_bytes: 0, by_satellite: {}, by_band: {} },
-        });
-      return Promise.resolve({ data: {} });
-    });
+    // Default handlers already return zero-valued stats — no overrides needed.
     renderWithProviders(<CleanupTab />);
     await waitFor(() => {
       expect(screen.getByText(/Storage Usage/i)).toBeInTheDocument();
@@ -90,36 +55,38 @@ describe('CleanupTab - Defensive Scenarios', () => {
   });
 
   it('renders multiple rules', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/cleanup-rules')
-        return Promise.resolve({
-          data: [
-            {
-              id: '1',
-              name: 'Age Rule',
-              rule_type: 'max_age_days',
-              value: 30,
-              protect_collections: true,
-              is_active: true,
-              created_at: '2024-06-01',
-            },
-            {
-              id: '2',
-              name: 'Size Rule',
-              rule_type: 'max_storage_gb',
-              value: 100,
-              protect_collections: false,
-              is_active: false,
-              created_at: '2024-06-01',
-            },
-          ],
-        });
-      if (url === '/satellite/frames/stats')
-        return Promise.resolve({
-          data: { total_frames: 500, total_size_bytes: 50_000_000, by_satellite: {}, by_band: {} },
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/cleanup-rules', () =>
+        HttpResponse.json([
+          {
+            id: '1',
+            name: 'Age Rule',
+            rule_type: 'max_age_days',
+            value: 30,
+            protect_collections: true,
+            is_active: true,
+            created_at: '2024-06-01',
+          },
+          {
+            id: '2',
+            name: 'Size Rule',
+            rule_type: 'max_storage_gb',
+            value: 100,
+            protect_collections: false,
+            is_active: false,
+            created_at: '2024-06-01',
+          },
+        ]),
+      ),
+      http.get('*/api/satellite/frames/stats', () =>
+        HttpResponse.json({
+          total_frames: 500,
+          total_size_bytes: 50_000_000,
+          by_satellite: {},
+          by_band: {},
+        }),
+      ),
+    );
     renderWithProviders(<CleanupTab />);
     await waitFor(() => {
       expect(screen.getByText('Age Rule')).toBeInTheDocument();

--- a/frontend/src/test/CleanupTabExtended.test.tsx
+++ b/frontend/src/test/CleanupTabExtended.test.tsx
@@ -1,44 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { http, HttpResponse, delay } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: { deleted_frames: 5, freed_bytes: 10240 } })),
-    put: vi.fn(() => Promise.resolve({ data: { is_active: false } })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({
   showToast: vi.fn(),
 }));
 
 import CleanupTab from '../components/GoesData/CleanupTab';
-import api from '../api/client';
 
-const mockedApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
-  post: ReturnType<typeof vi.fn>;
+const server = setupMswServer();
+
+const STATS_WITH_DATA = {
+  total_frames: 500,
+  total_size_bytes: 5368709120,
+  by_satellite: { 'GOES-16': { count: 300, size: 3e9 } },
+  by_band: { C02: { count: 200, size: 2e9 } },
 };
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/cleanup-rules') return Promise.resolve({ data: [] });
-    if (url === '/satellite/frames/stats') {
-      return Promise.resolve({
-        data: {
-          total_frames: 500,
-          total_size_bytes: 5368709120,
-          by_satellite: { 'GOES-16': { count: 300, size: 3e9 } },
-          by_band: { C02: { count: 200, size: 2e9 } },
-        },
-      });
-    }
-    return Promise.resolve({ data: {} });
-  });
+  server.use(
+    http.get('*/api/satellite/frames/stats', () => HttpResponse.json(STATS_WITH_DATA)),
+  );
 });
 
 describe('CleanupTab - confirm before cleanup', () => {
@@ -52,23 +36,37 @@ describe('CleanupTab - confirm before cleanup', () => {
   });
 
   it('runs cleanup when confirmed', async () => {
+    const runSpy = vi.fn();
+    server.use(
+      http.post('*/api/satellite/cleanup/run', () => {
+        runSpy();
+        return HttpResponse.json({ deleted_frames: 5, freed_bytes: 10240 });
+      }),
+    );
     renderWithProviders(<CleanupTab />);
     await waitFor(() => expect(screen.getByText('Run Now')).toBeInTheDocument());
 
     fireEvent.click(screen.getByText('Run Now'));
     fireEvent.click(screen.getByText('Run Cleanup'));
     await waitFor(() => {
-      expect(mockedApi.post).toHaveBeenCalledWith('/satellite/cleanup/run');
+      expect(runSpy).toHaveBeenCalled();
     });
   });
 
   it('does not run cleanup when cancelled', async () => {
+    const runSpy = vi.fn();
+    server.use(
+      http.post('*/api/satellite/cleanup/run', () => {
+        runSpy();
+        return HttpResponse.json({ deleted_frames: 0, freed_bytes: 0 });
+      }),
+    );
     renderWithProviders(<CleanupTab />);
     await waitFor(() => expect(screen.getByText('Run Now')).toBeInTheDocument());
 
     fireEvent.click(screen.getByText('Run Now'));
     fireEvent.click(screen.getByText('Cancel'));
-    expect(mockedApi.post).not.toHaveBeenCalled();
+    expect(runSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -81,7 +79,16 @@ describe('CleanupTab - storage stats display', () => {
   });
 
   it('shows skeleton when stats loading', () => {
-    mockedApi.get.mockImplementation(() => new Promise(() => {}));
+    server.use(
+      http.get('*/api/satellite/frames/stats', async () => {
+        await delay('infinite');
+        return HttpResponse.json({});
+      }),
+      http.get('*/api/satellite/cleanup-rules', async () => {
+        await delay('infinite');
+        return HttpResponse.json([]);
+      }),
+    );
     renderWithProviders(<CleanupTab />);
     // Should show skeleton placeholders
     expect(document.querySelectorAll('.skeleton-shimmer').length).toBeGreaterThan(0);

--- a/frontend/src/test/CleanupTabExtended.test.tsx
+++ b/frontend/src/test/CleanupTabExtended.test.tsx
@@ -20,9 +20,7 @@ const STATS_WITH_DATA = {
 };
 
 beforeEach(() => {
-  server.use(
-    http.get('*/api/satellite/frames/stats', () => HttpResponse.json(STATS_WITH_DATA)),
-  );
+  server.use(http.get('*/api/satellite/frames/stats', () => HttpResponse.json(STATS_WITH_DATA)));
 });
 
 describe('CleanupTab - confirm before cleanup', () => {

--- a/frontend/src/test/CollectionsTabDefensive.test.tsx
+++ b/frontend/src/test/CollectionsTabDefensive.test.tsx
@@ -1,15 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse, delay } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: [] })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-    put: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
 vi.mock('../components/GoesData/AnimationPlayer', () => ({
@@ -23,18 +16,8 @@ vi.mock('../components/GoesData/AnimationPlayer', () => ({
 }));
 
 import CollectionsTab from '../components/GoesData/CollectionsTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-    return Promise.resolve({ data: {} });
-  });
-});
+const server = setupMswServer();
 
 describe('CollectionsTab - Defensive Scenarios', () => {
   it('renders create collection input', () => {
@@ -43,14 +26,20 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('shows loading skeletons', () => {
-    mockedApi.get.mockReturnValue(new Promise(() => {}));
+    // Never-resolving handler to keep query in pending state.
+    server.use(
+      http.get('*/api/satellite/collections', async () => {
+        await delay('infinite');
+        return HttpResponse.json([]);
+      }),
+    );
     renderWithProviders(<CollectionsTab />);
     const pulseElements = document.querySelectorAll('.skeleton-shimmer');
     expect(pulseElements.length).toBeGreaterThan(0);
   });
 
   it('shows error state when API fails', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Server error'));
+    server.use(http.get('*/api/satellite/collections', () => HttpResponse.error()));
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(screen.getByText(/Failed to load collections/i)).toBeInTheDocument();
@@ -65,24 +54,22 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('handles collections API returning paginated object', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections')
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                id: '1',
-                name: 'Test',
-                description: 'desc',
-                frame_count: 5,
-                created_at: '2024-01-01',
-              },
-            ],
-            total: 1,
-          },
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: '1',
+              name: 'Test',
+              description: 'desc',
+              frame_count: 5,
+              created_at: '2024-01-01',
+            },
+          ],
+          total: 1,
+        }),
+      ),
+    );
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(screen.getByText('Test')).toBeInTheDocument();
@@ -91,10 +78,7 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('handles collections API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections') return Promise.resolve({ data: null });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/collections', () => HttpResponse.json(null)));
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(screen.getByText(/Create your first collection/i)).toBeInTheDocument();
@@ -102,10 +86,9 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('handles collections API returning undefined', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections') return Promise.resolve({ data: undefined });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () => new HttpResponse('', { status: 200 })),
+    );
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(screen.getByText(/Create your first collection/i)).toBeInTheDocument();
@@ -113,21 +96,19 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('renders collection with zero frame_count', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections')
-        return Promise.resolve({
-          data: [
-            {
-              id: '1',
-              name: 'Empty Col',
-              description: '',
-              frame_count: 0,
-              created_at: '2024-01-01',
-            },
-          ],
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () =>
+        HttpResponse.json([
+          {
+            id: '1',
+            name: 'Empty Col',
+            description: '',
+            frame_count: 0,
+            created_at: '2024-01-01',
+          },
+        ]),
+      ),
+    );
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(screen.getByText('Empty Col')).toBeInTheDocument();
@@ -136,21 +117,19 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('renders collection with null frame_count', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections')
-        return Promise.resolve({
-          data: [
-            {
-              id: '1',
-              name: 'Null Count',
-              description: '',
-              frame_count: null,
-              created_at: '2024-01-01',
-            },
-          ],
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () =>
+        HttpResponse.json([
+          {
+            id: '1',
+            name: 'Null Count',
+            description: '',
+            frame_count: null,
+            created_at: '2024-01-01',
+          },
+        ]),
+      ),
+    );
     const { container } = renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(container.innerHTML).toContain('Null Count');
@@ -173,15 +152,13 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('shows edit/delete buttons on collection cards', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections')
-        return Promise.resolve({
-          data: [
-            { id: '1', name: 'Test', description: '', frame_count: 3, created_at: '2024-01-01' },
-          ],
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () =>
+        HttpResponse.json([
+          { id: '1', name: 'Test', description: '', frame_count: 3, created_at: '2024-01-01' },
+        ]),
+      ),
+    );
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       expect(screen.getByText('Edit')).toBeInTheDocument();
@@ -190,15 +167,13 @@ describe('CollectionsTab - Defensive Scenarios', () => {
   });
 
   it('animate button disabled when frame_count is 0', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/collections')
-        return Promise.resolve({
-          data: [
-            { id: '1', name: 'Empty', description: '', frame_count: 0, created_at: '2024-01-01' },
-          ],
-        });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () =>
+        HttpResponse.json([
+          { id: '1', name: 'Empty', description: '', frame_count: 0, created_at: '2024-01-01' },
+        ]),
+      ),
+    );
     renderWithProviders(<CollectionsTab />);
     await waitFor(() => {
       const animBtn = screen.getByLabelText(/Animate collection Empty/);

--- a/frontend/src/test/CollectionsTabExtended.test.tsx
+++ b/frontend/src/test/CollectionsTabExtended.test.tsx
@@ -1,24 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockGet = vi.fn((_url?: string) => Promise.resolve({ data: [] as unknown[] }));
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockPost = vi.fn((_url?: string, _data?: unknown) => Promise.resolve({ data: {} }));
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockPut = vi.fn((_url?: string, _data?: unknown) => Promise.resolve({ data: {} }));
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockDelete = vi.fn((_url?: string) => Promise.resolve({}));
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: (url: string) => mockGet(url),
-    post: (url: string, data: unknown) => mockPost(url, data),
-    put: (url: string, data: unknown) => mockPut(url, data),
-    delete: (url: string) => mockDelete(url),
-  },
-}));
+import { http, HttpResponse } from 'msw';
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
 
@@ -31,6 +15,8 @@ vi.mock('../components/GoesData/AnimationPlayer', () => ({
 }));
 
 import CollectionsTab from '../components/GoesData/CollectionsTab';
+
+const server = setupMswServer();
 
 function renderWith(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -56,12 +42,12 @@ const collections = [
 
 describe('CollectionsTab extended', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockGet.mockImplementation((url?: string) => {
-      if (url === '/satellite/collections') return Promise.resolve({ data: collections });
-      if (url?.includes('/frames')) return Promise.resolve({ data: [{ id: 'f1' }, { id: 'f2' }] });
-      return Promise.resolve({ data: [] });
-    });
+    server.use(
+      http.get('*/api/satellite/collections', () => HttpResponse.json(collections)),
+      http.get('*/api/satellite/collections/:id/frames', () =>
+        HttpResponse.json([{ id: 'f1' }, { id: 'f2' }]),
+      ),
+    );
   });
 
   it('renders collection cards with data', async () => {
@@ -72,22 +58,34 @@ describe('CollectionsTab extended', () => {
   });
 
   it('creates a collection on Enter key', async () => {
+    const postSpy = vi.fn<(body: unknown) => void>();
+    server.use(
+      http.post('*/api/satellite/collections', async ({ request }) => {
+        postSpy(await request.json());
+        return HttpResponse.json({ id: 'new', name: 'New Coll', frame_count: 0 });
+      }),
+    );
     renderWith(<CollectionsTab />);
     const input = screen.getByPlaceholderText('New collection name');
     fireEvent.change(input, { target: { value: 'New Coll' } });
     fireEvent.keyDown(input, { key: 'Enter' });
-    await waitFor(() =>
-      expect(mockPost).toHaveBeenCalledWith('/satellite/collections', { name: 'New Coll' }),
-    );
+    await waitFor(() => expect(postSpy).toHaveBeenCalledWith({ name: 'New Coll' }));
   });
 
   it('creates a collection on button click', async () => {
+    const postSpy = vi.fn();
+    server.use(
+      http.post('*/api/satellite/collections', () => {
+        postSpy();
+        return HttpResponse.json({ id: 'new', name: 'Test', frame_count: 0 });
+      }),
+    );
     renderWith(<CollectionsTab />);
     fireEvent.change(screen.getByPlaceholderText('New collection name'), {
       target: { value: 'Test' },
     });
     fireEvent.click(screen.getByText('Create'));
-    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
   });
 
   it('does not create when name is empty', () => {
@@ -96,6 +94,13 @@ describe('CollectionsTab extended', () => {
   });
 
   it('enters edit mode and saves', async () => {
+    const putSpy = vi.fn<(url: string, body: unknown) => void>();
+    server.use(
+      http.put('*/api/satellite/collections/:id', async ({ request, params }) => {
+        putSpy(`/satellite/collections/${params.id}`, await request.json());
+        return HttpResponse.json({ id: params.id, name: 'Renamed', frame_count: 5 });
+      }),
+    );
     renderWith(<CollectionsTab />);
     await waitFor(() => expect(screen.getByText('Collection A')).toBeInTheDocument());
     const editBtns = screen.getAllByText('Edit');
@@ -104,7 +109,7 @@ describe('CollectionsTab extended', () => {
     fireEvent.change(editInput, { target: { value: 'Renamed' } });
     fireEvent.keyDown(editInput, { key: 'Enter' });
     await waitFor(() =>
-      expect(mockPut).toHaveBeenCalledWith('/satellite/collections/c1', { name: 'Renamed' }),
+      expect(putSpy).toHaveBeenCalledWith('/satellite/collections/c1', { name: 'Renamed' }),
     );
   });
 
@@ -117,6 +122,13 @@ describe('CollectionsTab extended', () => {
   });
 
   it('saves edit via Save button', async () => {
+    const putSpy = vi.fn();
+    server.use(
+      http.put('*/api/satellite/collections/:id', () => {
+        putSpy();
+        return HttpResponse.json({ id: 'c1', name: 'Updated', frame_count: 5 });
+      }),
+    );
     renderWith(<CollectionsTab />);
     await waitFor(() => expect(screen.getByText('Collection A')).toBeInTheDocument());
     fireEvent.click(screen.getAllByText('Edit')[0]);
@@ -124,14 +136,21 @@ describe('CollectionsTab extended', () => {
       target: { value: 'Updated' },
     });
     fireEvent.click(screen.getByText('Save'));
-    await waitFor(() => expect(mockPut).toHaveBeenCalled());
+    await waitFor(() => expect(putSpy).toHaveBeenCalled());
   });
 
   it('deletes a collection', async () => {
+    const deleteSpy = vi.fn<(url: string) => void>();
+    server.use(
+      http.delete('*/api/satellite/collections/:id', ({ params }) => {
+        deleteSpy(`/satellite/collections/${params.id}`);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
     renderWith(<CollectionsTab />);
     await waitFor(() => expect(screen.getByText('Collection A')).toBeInTheDocument());
     fireEvent.click(screen.getAllByText('Delete')[0]);
-    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('/satellite/collections/c1'));
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith('/satellite/collections/c1'));
   });
 
   it('opens animation player on animate click', async () => {
@@ -163,7 +182,7 @@ describe('CollectionsTab extended', () => {
   });
 
   it('shows empty state when no collections', async () => {
-    mockGet.mockImplementation(() => Promise.resolve({ data: [] }));
+    server.use(http.get('*/api/satellite/collections', () => HttpResponse.json([])));
     renderWith(<CollectionsTab />);
     await waitFor(() =>
       expect(screen.getByText(/create your first collection/i)).toBeInTheDocument(),

--- a/frontend/src/test/CompositesTab.test.tsx
+++ b/frontend/src/test/CompositesTab.test.tsx
@@ -1,45 +1,29 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 import CompositesTab from '../components/GoesData/CompositesTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
+const server = setupMswServer();
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/products') {
-      return Promise.resolve({
-        data: {
-          satellites: ['GOES-16'],
-          sectors: [{ id: 'CONUS', name: 'CONUS', product: 'x' }],
-          bands: [{ id: 'C02', description: 'Red' }],
-        },
-      });
-    }
-    if (url === '/satellite/composite-recipes') {
-      return Promise.resolve({
-        data: [
-          { id: 'true_color', name: 'True Color', bands: ['C02', 'C03', 'C01'] },
-          { id: 'fire_detection', name: 'Fire Detection', bands: ['C07', 'C06', 'C02'] },
-        ],
-      });
-    }
-    if (url.startsWith('/satellite/composites')) {
-      return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 20 } });
-    }
-    return Promise.resolve({ data: {} });
-  });
+  server.use(
+    http.get('*/api/satellite/products', () =>
+      HttpResponse.json({
+        satellites: ['GOES-16'],
+        sectors: [{ id: 'CONUS', name: 'CONUS', product: 'x' }],
+        bands: [{ id: 'C02', description: 'Red' }],
+      }),
+    ),
+    http.get('*/api/satellite/composite-recipes', () =>
+      HttpResponse.json([
+        { id: 'true_color', name: 'True Color', bands: ['C02', 'C03', 'C01'] },
+        { id: 'fire_detection', name: 'Fire Detection', bands: ['C07', 'C06', 'C02'] },
+      ]),
+    ),
+  );
 });
 
 describe('CompositesTab', () => {
@@ -67,41 +51,33 @@ describe('CompositesTab', () => {
   });
 
   it('shows composites when data exists', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/composite-recipes') {
-        return Promise.resolve({
-          data: [{ id: 'true_color', name: 'True Color', bands: ['C02'] }],
-        });
-      }
-      if (url.startsWith('/satellite/composites')) {
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                id: '1',
-                name: 'True Color',
-                recipe: 'true_color',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                capture_time: '2024-06-01T12:00:00',
-                file_path: null,
-                file_size: 0,
-                status: 'completed',
-                error: '',
-                created_at: '2024-06-01T12:05:00',
-              },
-            ],
-            total: 1,
-            page: 1,
-            limit: 20,
-          },
-        });
-      }
-      if (url === '/satellite/products') {
-        return Promise.resolve({ data: { satellites: ['GOES-16'], sectors: [], bands: [] } });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/composite-recipes', () =>
+        HttpResponse.json([{ id: 'true_color', name: 'True Color', bands: ['C02'] }]),
+      ),
+      http.get('*/api/satellite/composites', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: '1',
+              name: 'True Color',
+              recipe: 'true_color',
+              satellite: 'GOES-16',
+              sector: 'CONUS',
+              capture_time: '2024-06-01T12:00:00',
+              file_path: null,
+              file_size: 0,
+              status: 'completed',
+              error: '',
+              created_at: '2024-06-01T12:05:00',
+            },
+          ],
+          total: 1,
+          page: 1,
+          limit: 20,
+        }),
+      ),
+    );
     renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(screen.getAllByText(/True Color/i).length).toBeGreaterThan(0);

--- a/frontend/src/test/CompositesTabDefensive.test.tsx
+++ b/frontend/src/test/CompositesTabDefensive.test.tsx
@@ -1,53 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
 
 import CompositesTab from '../components/GoesData/CompositesTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/products')
-      return Promise.resolve({
-        data: {
-          satellites: ['GOES-16'],
-          sectors: [{ id: 'CONUS', name: 'CONUS', product: 'x' }],
-          bands: [{ id: 'C02', description: 'Red' }],
-        },
-      });
-    if (url === '/satellite/composite-recipes')
-      return Promise.resolve({
-        data: [{ id: 'true_color', name: 'True Color', bands: ['C02', 'C03', 'C01'] }],
-      });
-    if (url.startsWith('/satellite/composites'))
-      return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 20 } });
-    return Promise.resolve({ data: {} });
-  });
-});
+const server = setupMswServer();
 
 describe('CompositesTab - Defensive Scenarios', () => {
   it('handles recipes API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/composite-recipes') return Promise.resolve({ data: null });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], sectors: [], bands: [] } });
-      if (url.startsWith('/satellite/composites'))
-        return Promise.resolve({ data: { items: [], total: 0 } });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/composite-recipes', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -55,14 +20,11 @@ describe('CompositesTab - Defensive Scenarios', () => {
   });
 
   it('handles composites API returning null items', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/composite-recipes') return Promise.resolve({ data: [] });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], sectors: [], bands: [] } });
-      if (url.startsWith('/satellite/composites'))
-        return Promise.resolve({ data: { items: null, total: 0 } });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/composites', () =>
+        HttpResponse.json({ items: null, total: 0 }),
+      ),
+    );
     const { container } = renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -70,13 +32,7 @@ describe('CompositesTab - Defensive Scenarios', () => {
   });
 
   it('handles products API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/products') return Promise.resolve({ data: null });
-      if (url === '/satellite/composite-recipes') return Promise.resolve({ data: [] });
-      if (url.startsWith('/satellite/composites'))
-        return Promise.resolve({ data: { items: [], total: 0 } });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/products', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -84,7 +40,11 @@ describe('CompositesTab - Defensive Scenarios', () => {
   });
 
   it('handles all APIs failing', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Server error'));
+    server.use(
+      http.get('*/api/satellite/composite-recipes', () => HttpResponse.error()),
+      http.get('*/api/satellite/composites', () => HttpResponse.error()),
+      http.get('*/api/satellite/products', () => HttpResponse.error()),
+    );
     const { container } = renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -92,64 +52,62 @@ describe('CompositesTab - Defensive Scenarios', () => {
   });
 
   it('renders composites with various statuses', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/composite-recipes')
-        return Promise.resolve({
-          data: [{ id: 'true_color', name: 'True Color', bands: ['C02'] }],
-        });
-      if (url.startsWith('/satellite/composites'))
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                id: '1',
-                name: 'True Color',
-                recipe: 'true_color',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                capture_time: '2024-06-01T12:00:00',
-                file_path: '/tmp/c.png',
-                file_size: 1024,
-                status: 'completed',
-                error: '',
-                created_at: '2024-06-01',
-              },
-              {
-                id: '2',
-                name: 'True Color',
-                recipe: 'true_color',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                capture_time: '2024-06-01T13:00:00',
-                file_path: null,
-                file_size: 0,
-                status: 'failed',
-                error: 'Missing bands',
-                created_at: '2024-06-01',
-              },
-              {
-                id: '3',
-                name: 'True Color',
-                recipe: 'true_color',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                capture_time: '2024-06-01T14:00:00',
-                file_path: null,
-                file_size: 0,
-                status: 'pending',
-                error: '',
-                created_at: '2024-06-01',
-              },
-            ],
-            total: 3,
-            page: 1,
-            limit: 20,
-          },
-        });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: ['GOES-16'], sectors: [], bands: [] } });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/composite-recipes', () =>
+        HttpResponse.json([{ id: 'true_color', name: 'True Color', bands: ['C02'] }]),
+      ),
+      http.get('*/api/satellite/composites', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: '1',
+              name: 'True Color',
+              recipe: 'true_color',
+              satellite: 'GOES-16',
+              sector: 'CONUS',
+              capture_time: '2024-06-01T12:00:00',
+              file_path: '/tmp/c.png',
+              file_size: 1024,
+              status: 'completed',
+              error: '',
+              created_at: '2024-06-01',
+            },
+            {
+              id: '2',
+              name: 'True Color',
+              recipe: 'true_color',
+              satellite: 'GOES-16',
+              sector: 'CONUS',
+              capture_time: '2024-06-01T13:00:00',
+              file_path: null,
+              file_size: 0,
+              status: 'failed',
+              error: 'Missing bands',
+              created_at: '2024-06-01',
+            },
+            {
+              id: '3',
+              name: 'True Color',
+              recipe: 'true_color',
+              satellite: 'GOES-16',
+              sector: 'CONUS',
+              capture_time: '2024-06-01T14:00:00',
+              file_path: null,
+              file_size: 0,
+              status: 'pending',
+              error: '',
+              created_at: '2024-06-01',
+            },
+          ],
+          total: 3,
+          page: 1,
+          limit: 20,
+        }),
+      ),
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({ satellites: ['GOES-16'], sectors: [], bands: [] }),
+      ),
+    );
     renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(screen.getAllByText(/True Color/i).length).toBeGreaterThan(0);
@@ -157,23 +115,20 @@ describe('CompositesTab - Defensive Scenarios', () => {
   });
 
   it('handles recipes returned as object with items', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/composite-recipes')
-        return Promise.resolve({
-          data: { items: [{ id: 'true_color', name: 'True Color', bands: ['C01', 'C02', 'C03'] }] },
-        });
-      if (url === '/satellite/products')
-        return Promise.resolve({
-          data: {
-            satellites: ['GOES-16'],
-            sectors: [{ id: 'CONUS', name: 'CONUS', product: 'ABI' }],
-            bands: [],
-          },
-        });
-      if (url.startsWith('/satellite/composites'))
-        return Promise.resolve({ data: { items: [], total: 0 } });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/composite-recipes', () =>
+        HttpResponse.json({
+          items: [{ id: 'true_color', name: 'True Color', bands: ['C01', 'C02', 'C03'] }],
+        }),
+      ),
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({
+          satellites: ['GOES-16'],
+          sectors: [{ id: 'CONUS', name: 'CONUS', product: 'ABI' }],
+          bands: [],
+        }),
+      ),
+    );
     renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(screen.getAllByText(/True Color/i).length).toBeGreaterThan(0);
@@ -181,14 +136,7 @@ describe('CompositesTab - Defensive Scenarios', () => {
   });
 
   it('handles empty recipes list', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/composite-recipes') return Promise.resolve({ data: [] });
-      if (url === '/satellite/products')
-        return Promise.resolve({ data: { satellites: [], sectors: [], bands: [] } });
-      if (url.startsWith('/satellite/composites'))
-        return Promise.resolve({ data: { items: [], total: 0 } });
-      return Promise.resolve({ data: {} });
-    });
+    // Default handlers already serve empty recipes — no override needed.
     const { container } = renderWithProviders(<CompositesTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);

--- a/frontend/src/test/CompositesTabDefensive.test.tsx
+++ b/frontend/src/test/CompositesTabDefensive.test.tsx
@@ -21,9 +21,7 @@ describe('CompositesTab - Defensive Scenarios', () => {
 
   it('handles composites API returning null items', async () => {
     server.use(
-      http.get('*/api/satellite/composites', () =>
-        HttpResponse.json({ items: null, total: 0 }),
-      ),
+      http.get('*/api/satellite/composites', () => HttpResponse.json({ items: null, total: 0 })),
     );
     const { container } = renderWithProviders(<CompositesTab />);
     await waitFor(() => {

--- a/frontend/src/test/GapsTab.test.tsx
+++ b/frontend/src/test/GapsTab.test.tsx
@@ -18,9 +18,7 @@ const DEFAULT_PRODUCTS = {
 };
 
 beforeEach(() => {
-  server.use(
-    http.get('*/api/satellite/products', () => HttpResponse.json(DEFAULT_PRODUCTS)),
-  );
+  server.use(http.get('*/api/satellite/products', () => HttpResponse.json(DEFAULT_PRODUCTS)));
 });
 
 describe('GapsTab', () => {

--- a/frontend/src/test/GapsTab.test.tsx
+++ b/frontend/src/test/GapsTab.test.tsx
@@ -1,36 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 import GapsTab from '../components/GoesData/GapsTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
+const server = setupMswServer();
+
+// Default product list used by most tests below.
+const DEFAULT_PRODUCTS = {
+  satellites: ['GOES-16', 'GOES-19'],
+  bands: [
+    { id: 'C02', description: 'Red' },
+    { id: 'C13', description: 'IR' },
+  ],
+};
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/products') {
-      return Promise.resolve({
-        data: {
-          satellites: ['GOES-16', 'GOES-19'],
-          bands: [
-            { id: 'C02', description: 'Red' },
-            { id: 'C13', description: 'IR' },
-          ],
-        },
-      });
-    }
-    return Promise.resolve({ data: {} });
-  });
+  server.use(
+    http.get('*/api/satellite/products', () => HttpResponse.json(DEFAULT_PRODUCTS)),
+  );
 });
 
 describe('GapsTab', () => {
@@ -46,39 +36,34 @@ describe('GapsTab', () => {
   });
 
   it('shows coverage percentage after scan', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/gaps') {
-        return Promise.resolve({
-          data: {
-            coverage_percent: 87.5,
-            gap_count: 2,
-            total_frames: 144,
-            expected_frames: 160,
-            time_range: { start: '2024-06-01T00:00:00Z', end: '2024-06-01T23:59:59Z' },
-            gaps: [
-              {
-                start: '2024-06-01T06:00:00Z',
-                end: '2024-06-01T07:00:00Z',
-                duration_minutes: 60,
-                expected_frames: 6,
-              },
-              {
-                start: '2024-06-01T14:00:00Z',
-                end: '2024-06-01T14:30:00Z',
-                duration_minutes: 30,
-                expected_frames: 3,
-              },
-            ],
-          },
-        });
-      }
-      if (url === '/satellite/products') {
-        return Promise.resolve({
-          data: { satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] },
-        });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({ satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] }),
+      ),
+      http.get('*/api/satellite/gaps', () =>
+        HttpResponse.json({
+          coverage_percent: 87.5,
+          gap_count: 2,
+          total_frames: 144,
+          expected_frames: 160,
+          time_range: { start: '2024-06-01T00:00:00Z', end: '2024-06-01T23:59:59Z' },
+          gaps: [
+            {
+              start: '2024-06-01T06:00:00Z',
+              end: '2024-06-01T07:00:00Z',
+              duration_minutes: 60,
+              expected_frames: 6,
+            },
+            {
+              start: '2024-06-01T14:00:00Z',
+              end: '2024-06-01T14:30:00Z',
+              duration_minutes: 30,
+              expected_frames: 3,
+            },
+          ],
+        }),
+      ),
+    );
 
     renderWithProviders(<GapsTab />);
     fireEvent.click(screen.getByText('Detect Gaps'));
@@ -91,33 +76,28 @@ describe('GapsTab', () => {
   });
 
   it('renders gap list items', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/gaps') {
-        return Promise.resolve({
-          data: {
-            coverage_percent: 90,
-            gap_count: 1,
-            total_frames: 100,
-            expected_frames: 110,
-            time_range: null,
-            gaps: [
-              {
-                start: '2024-06-01T06:00:00Z',
-                end: '2024-06-01T07:00:00Z',
-                duration_minutes: 60,
-                expected_frames: 6,
-              },
-            ],
-          },
-        });
-      }
-      if (url === '/satellite/products') {
-        return Promise.resolve({
-          data: { satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] },
-        });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({ satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] }),
+      ),
+      http.get('*/api/satellite/gaps', () =>
+        HttpResponse.json({
+          coverage_percent: 90,
+          gap_count: 1,
+          total_frames: 100,
+          expected_frames: 110,
+          time_range: null,
+          gaps: [
+            {
+              start: '2024-06-01T06:00:00Z',
+              end: '2024-06-01T07:00:00Z',
+              duration_minutes: 60,
+              expected_frames: 6,
+            },
+          ],
+        }),
+      ),
+    );
 
     renderWithProviders(<GapsTab />);
     fireEvent.click(screen.getByText('Detect Gaps'));
@@ -130,26 +110,21 @@ describe('GapsTab', () => {
   });
 
   it('shows no-gaps message when coverage is 100%', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/gaps') {
-        return Promise.resolve({
-          data: {
-            coverage_percent: 100,
-            gap_count: 0,
-            total_frames: 144,
-            expected_frames: 144,
-            time_range: null,
-            gaps: [],
-          },
-        });
-      }
-      if (url === '/satellite/products') {
-        return Promise.resolve({
-          data: { satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] },
-        });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({ satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] }),
+      ),
+      http.get('*/api/satellite/gaps', () =>
+        HttpResponse.json({
+          coverage_percent: 100,
+          gap_count: 0,
+          total_frames: 144,
+          expected_frames: 144,
+          time_range: null,
+          gaps: [],
+        }),
+      ),
+    );
 
     renderWithProviders(<GapsTab />);
     fireEvent.click(screen.getByText('Detect Gaps'));
@@ -160,33 +135,28 @@ describe('GapsTab', () => {
   });
 
   it('backfill button shows confirmation dialog', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/gaps') {
-        return Promise.resolve({
-          data: {
-            coverage_percent: 90,
-            gap_count: 1,
-            total_frames: 100,
-            expected_frames: 110,
-            time_range: null,
-            gaps: [
-              {
-                start: '2024-06-01T06:00:00Z',
-                end: '2024-06-01T07:00:00Z',
-                duration_minutes: 60,
-                expected_frames: 6,
-              },
-            ],
-          },
-        });
-      }
-      if (url === '/satellite/products') {
-        return Promise.resolve({
-          data: { satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] },
-        });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    server.use(
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({ satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] }),
+      ),
+      http.get('*/api/satellite/gaps', () =>
+        HttpResponse.json({
+          coverage_percent: 90,
+          gap_count: 1,
+          total_frames: 100,
+          expected_frames: 110,
+          time_range: null,
+          gaps: [
+            {
+              start: '2024-06-01T06:00:00Z',
+              end: '2024-06-01T07:00:00Z',
+              duration_minutes: 60,
+              expected_frames: 6,
+            },
+          ],
+        }),
+      ),
+    );
 
     renderWithProviders(<GapsTab />);
     fireEvent.click(screen.getByText('Detect Gaps'));
@@ -202,33 +172,33 @@ describe('GapsTab', () => {
   });
 
   it('confirm backfill calls API', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/gaps') {
-        return Promise.resolve({
-          data: {
-            coverage_percent: 90,
-            gap_count: 1,
-            total_frames: 100,
-            expected_frames: 110,
-            time_range: null,
-            gaps: [
-              {
-                start: '2024-06-01T06:00:00Z',
-                end: '2024-06-01T07:00:00Z',
-                duration_minutes: 60,
-                expected_frames: 6,
-              },
-            ],
-          },
-        });
-      }
-      if (url === '/satellite/products') {
-        return Promise.resolve({
-          data: { satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] },
-        });
-      }
-      return Promise.resolve({ data: {} });
-    });
+    const backfillSpy = vi.fn<(body: unknown) => void>();
+    server.use(
+      http.get('*/api/satellite/products', () =>
+        HttpResponse.json({ satellites: ['GOES-19'], bands: [{ id: 'C02', description: 'Red' }] }),
+      ),
+      http.get('*/api/satellite/gaps', () =>
+        HttpResponse.json({
+          coverage_percent: 90,
+          gap_count: 1,
+          total_frames: 100,
+          expected_frames: 110,
+          time_range: null,
+          gaps: [
+            {
+              start: '2024-06-01T06:00:00Z',
+              end: '2024-06-01T07:00:00Z',
+              duration_minutes: 60,
+              expected_frames: 6,
+            },
+          ],
+        }),
+      ),
+      http.post('*/api/satellite/backfill', async ({ request }) => {
+        backfillSpy(await request.json());
+        return HttpResponse.json({ job_id: 'bf-1' });
+      }),
+    );
 
     renderWithProviders(<GapsTab />);
     fireEvent.click(screen.getByText('Detect Gaps'));
@@ -240,8 +210,7 @@ describe('GapsTab', () => {
     fireEvent.click(screen.getByText('Confirm Backfill'));
 
     await waitFor(() => {
-      expect(mockedApi.post).toHaveBeenCalledWith(
-        '/satellite/backfill',
+      expect(backfillSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           satellite: 'GOES-19',
           band: 'C02',

--- a/frontend/src/test/GoesDataExtended.test.tsx
+++ b/frontend/src/test/GoesDataExtended.test.tsx
@@ -1,22 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-    put: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { http, HttpResponse } from 'msw';
+import { setupMswServer } from './mocks/msw';
 
 import GoesData from '../pages/GoesData';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
+const server = setupMswServer();
 
 function renderPage() {
   const qc = new QueryClient({
@@ -34,29 +25,15 @@ function renderPage() {
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/products') {
-      return Promise.resolve({
-        data: {
-          satellites: ['GOES-16', 'GOES-18'],
-          sectors: [{ id: 'CONUS', name: 'CONUS', product: 'ABI-L2-CMIPF' }],
-          bands: [{ id: 'C02', description: 'Red (0.64µm)' }],
-        },
-      });
-    }
-    if (url.includes('/frames')) {
-      return Promise.resolve({ data: { items: [], total: 0, page: 1, limit: 50 } });
-    }
-    if (url === '/satellite/collections') return Promise.resolve({ data: [] });
-    if (url === '/satellite/tags') return Promise.resolve({ data: [] });
-    if (url === '/satellite/frames/stats') {
-      return Promise.resolve({
-        data: { total_frames: 0, total_size_bytes: 0, by_satellite: {}, by_band: {} },
-      });
-    }
-    return Promise.resolve({ data: {} });
-  });
+  server.use(
+    http.get('*/api/satellite/products', () =>
+      HttpResponse.json({
+        satellites: ['GOES-16', 'GOES-18'],
+        sectors: [{ id: 'CONUS', name: 'CONUS', product: 'ABI-L2-CMIPF' }],
+        bands: [{ id: 'C02', description: 'Red (0.64µm)' }],
+      }),
+    ),
+  );
 });
 
 describe('GoesData page extended', () => {

--- a/frontend/src/test/NotificationBellDefensive.test.tsx
+++ b/frontend/src/test/NotificationBellDefensive.test.tsx
@@ -1,32 +1,27 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
 
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: [] })),
-    patch: vi.fn(() => Promise.resolve({})),
-  },
+// Stub the websocket-backed ConnectionStatus hook so happy-dom doesn't
+// try to open a real /ws/status connection alongside the MSW interceptor.
+vi.mock('../components/ConnectionStatus', () => ({
+  useIsWebSocketConnected: () => false,
 }));
 
 import NotificationBell from '../components/NotificationBell';
-import api from '../api/client';
+import { setupMswServer } from './mocks/msw';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
+const server = setupMswServer();
 
 function renderWithQuery(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe('NotificationBell - Defensive Scenarios', () => {
   it('handles API returning null', async () => {
-    mockedApi.get.mockResolvedValue({ data: null });
+    server.use(http.get('*/api/notifications', () => HttpResponse.json(null)));
     renderWithQuery(<NotificationBell />);
     expect(screen.getByRole('button')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button'));
@@ -36,7 +31,7 @@ describe('NotificationBell - Defensive Scenarios', () => {
   });
 
   it('handles API returning undefined', async () => {
-    mockedApi.get.mockResolvedValue({ data: undefined });
+    server.use(http.get('*/api/notifications', () => new HttpResponse('', { status: 200 })));
     renderWithQuery(<NotificationBell />);
     fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {
@@ -45,20 +40,22 @@ describe('NotificationBell - Defensive Scenarios', () => {
   });
 
   it('handles API returning paginated object instead of array', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: {
-        items: [
-          {
-            id: 'n1',
-            message: 'Test notification',
-            type: 'fetch_complete',
-            read: false,
-            created_at: '2026-01-01T12:00:00Z',
-          },
-        ],
-        total: 1,
-      },
-    });
+    server.use(
+      http.get('*/api/notifications', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'n1',
+              message: 'Test notification',
+              type: 'fetch_complete',
+              read: false,
+              created_at: '2026-01-01T12:00:00Z',
+            },
+          ],
+          total: 1,
+        }),
+      ),
+    );
     renderWithQuery(<NotificationBell />);
     fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {
@@ -67,14 +64,14 @@ describe('NotificationBell - Defensive Scenarios', () => {
   });
 
   it('handles API error gracefully (catches error)', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Network error'));
+    server.use(http.get('*/api/notifications', () => HttpResponse.error()));
     renderWithQuery(<NotificationBell />);
     // Should still render the bell button without crashing
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('handles empty notification list', async () => {
-    mockedApi.get.mockResolvedValue({ data: [] });
+    // Default handler already returns [] — no override needed.
     renderWithQuery(<NotificationBell />);
     fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {
@@ -83,31 +80,33 @@ describe('NotificationBell - Defensive Scenarios', () => {
   });
 
   it('shows unread count badge', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: [
-        {
-          id: 'n1',
-          message: 'Unread 1',
-          type: 'fetch_complete',
-          read: false,
-          created_at: '2026-01-01T12:00:00Z',
-        },
-        {
-          id: 'n2',
-          message: 'Unread 2',
-          type: 'fetch_complete',
-          read: false,
-          created_at: '2026-01-01T11:00:00Z',
-        },
-        {
-          id: 'n3',
-          message: 'Read',
-          type: 'fetch_complete',
-          read: true,
-          created_at: '2026-01-01T10:00:00Z',
-        },
-      ],
-    });
+    server.use(
+      http.get('*/api/notifications', () =>
+        HttpResponse.json([
+          {
+            id: 'n1',
+            message: 'Unread 1',
+            type: 'fetch_complete',
+            read: false,
+            created_at: '2026-01-01T12:00:00Z',
+          },
+          {
+            id: 'n2',
+            message: 'Unread 2',
+            type: 'fetch_complete',
+            read: false,
+            created_at: '2026-01-01T11:00:00Z',
+          },
+          {
+            id: 'n3',
+            message: 'Read',
+            type: 'fetch_complete',
+            read: true,
+            created_at: '2026-01-01T10:00:00Z',
+          },
+        ]),
+      ),
+    );
     renderWithQuery(<NotificationBell />);
     await waitFor(() => {
       expect(screen.getByText('2')).toBeInTheDocument();
@@ -122,7 +121,7 @@ describe('NotificationBell - Defensive Scenarios', () => {
       read: false,
       created_at: '2026-01-01T12:00:00Z',
     }));
-    mockedApi.get.mockResolvedValue({ data: notifications });
+    server.use(http.get('*/api/notifications', () => HttpResponse.json(notifications)));
     renderWithQuery(<NotificationBell />);
     await waitFor(() => {
       expect(screen.getByText('9+')).toBeInTheDocument();
@@ -130,17 +129,19 @@ describe('NotificationBell - Defensive Scenarios', () => {
   });
 
   it('shows no badge when all are read', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: [
-        {
-          id: 'n1',
-          message: 'Read',
-          type: 'fetch_complete',
-          read: true,
-          created_at: '2026-01-01T12:00:00Z',
-        },
-      ],
-    });
+    server.use(
+      http.get('*/api/notifications', () =>
+        HttpResponse.json([
+          {
+            id: 'n1',
+            message: 'Read',
+            type: 'fetch_complete',
+            read: true,
+            created_at: '2026-01-01T12:00:00Z',
+          },
+        ]),
+      ),
+    );
     renderWithQuery(<NotificationBell />);
     await waitFor(() => {
       // No badge text should be present for counts
@@ -157,7 +158,7 @@ describe('NotificationBell - Defensive Scenarios', () => {
       read: false,
       created_at: '2026-01-01T12:00:00Z',
     }));
-    mockedApi.get.mockResolvedValue({ data: notifications });
+    server.use(http.get('*/api/notifications', () => HttpResponse.json(notifications)));
     renderWithQuery(<NotificationBell />);
     fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {

--- a/frontend/src/test/PresetsTabDefensive.test.tsx
+++ b/frontend/src/test/PresetsTabDefensive.test.tsx
@@ -1,40 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-    post: vi.fn(() => Promise.resolve({ data: {} })),
-    put: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 vi.mock('../utils/toast', () => ({ showToast: vi.fn() }));
 
 import PresetsTab from '../components/GoesData/PresetsTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockedApi.get.mockImplementation((url: string) => {
-    if (url === '/satellite/fetch-presets') return Promise.resolve({ data: [] });
-    if (url === '/satellite/schedules') return Promise.resolve({ data: [] });
-    return Promise.resolve({ data: {} });
-  });
-});
+const server = setupMswServer();
 
 describe('PresetsTab - Defensive Scenarios', () => {
   it('handles presets API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/fetch-presets') return Promise.resolve({ data: null });
-      if (url === '/satellite/schedules') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/fetch-presets', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<PresetsTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -42,11 +20,7 @@ describe('PresetsTab - Defensive Scenarios', () => {
   });
 
   it('handles schedules API returning null', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/fetch-presets') return Promise.resolve({ data: [] });
-      if (url === '/satellite/schedules') return Promise.resolve({ data: null });
-      return Promise.resolve({ data: {} });
-    });
+    server.use(http.get('*/api/satellite/schedules', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<PresetsTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -54,7 +28,10 @@ describe('PresetsTab - Defensive Scenarios', () => {
   });
 
   it('handles all APIs failing', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Network error'));
+    server.use(
+      http.get('*/api/satellite/fetch-presets', () => HttpResponse.error()),
+      http.get('*/api/satellite/schedules', () => HttpResponse.error()),
+    );
     const { container } = renderWithProviders(<PresetsTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);
@@ -62,41 +39,13 @@ describe('PresetsTab - Defensive Scenarios', () => {
   });
 
   it('handles presets API returning paginated object', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/fetch-presets')
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                id: '1',
-                name: 'Test Preset',
-                satellite: 'GOES-16',
-                sector: 'CONUS',
-                band: 'C02',
-                description: '',
-                created_at: '2024-01-01',
-              },
-            ],
-            total: 1,
-          },
-        });
-      if (url === '/satellite/schedules') return Promise.resolve({ data: [] });
-      return Promise.resolve({ data: {} });
-    });
-    const { container } = renderWithProviders(<PresetsTab />);
-    await waitFor(() => {
-      expect(container.innerHTML.length).toBeGreaterThan(0);
-    });
-  });
-
-  it('handles schedule with null preset reference', async () => {
-    mockedApi.get.mockImplementation((url: string) => {
-      if (url === '/satellite/fetch-presets')
-        return Promise.resolve({
-          data: [
+    server.use(
+      http.get('*/api/satellite/fetch-presets', () =>
+        HttpResponse.json({
+          items: [
             {
               id: '1',
-              name: 'P1',
+              name: 'Test Preset',
               satellite: 'GOES-16',
               sector: 'CONUS',
               band: 'C02',
@@ -104,24 +53,46 @@ describe('PresetsTab - Defensive Scenarios', () => {
               created_at: '2024-01-01',
             },
           ],
-        });
-      if (url === '/satellite/schedules')
-        return Promise.resolve({
-          data: [
-            {
-              id: 's1',
-              name: 'Hourly',
-              preset_id: '1',
-              interval_minutes: 60,
-              is_active: true,
-              last_run_at: null,
-              next_run_at: null,
-              preset: null,
-            },
-          ],
-        });
-      return Promise.resolve({ data: {} });
+          total: 1,
+        }),
+      ),
+    );
+    const { container } = renderWithProviders(<PresetsTab />);
+    await waitFor(() => {
+      expect(container.innerHTML.length).toBeGreaterThan(0);
     });
+  });
+
+  it('handles schedule with null preset reference', async () => {
+    server.use(
+      http.get('*/api/satellite/fetch-presets', () =>
+        HttpResponse.json([
+          {
+            id: '1',
+            name: 'P1',
+            satellite: 'GOES-16',
+            sector: 'CONUS',
+            band: 'C02',
+            description: '',
+            created_at: '2024-01-01',
+          },
+        ]),
+      ),
+      http.get('*/api/satellite/schedules', () =>
+        HttpResponse.json([
+          {
+            id: 's1',
+            name: 'Hourly',
+            preset_id: '1',
+            interval_minutes: 60,
+            is_active: true,
+            last_run_at: null,
+            next_run_at: null,
+            preset: null,
+          },
+        ]),
+      ),
+    );
     const { container } = renderWithProviders(<PresetsTab />);
     await waitFor(() => {
       expect(container.innerHTML.length).toBeGreaterThan(0);

--- a/frontend/src/test/StatsTab.test.tsx
+++ b/frontend/src/test/StatsTab.test.tsx
@@ -1,33 +1,27 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse, delay } from 'msw';
 import { renderWithProviders } from './testUtils';
-
-vi.mock('../api/client', () => ({
-  default: {
-    get: vi.fn(() => Promise.resolve({ data: {} })),
-  },
-}));
+import { setupMswServer } from './mocks/msw';
 
 import StatsTab from '../components/GoesData/StatsTab';
-import api from '../api/client';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any;
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
+const server = setupMswServer();
 
 describe('StatsTab', () => {
   it('renders loading state', () => {
-    // Never resolve so it stays loading
-    mockedApi.get.mockReturnValue(new Promise(() => {}));
+    server.use(
+      http.get('*/api/satellite/frames/stats', async () => {
+        await delay('infinite');
+        return HttpResponse.json({});
+      }),
+    );
     renderWithProviders(<StatsTab />);
     expect(screen.getByText('Loading stats...')).toBeInTheDocument();
   });
 
   it('renders error state when API fails', async () => {
-    mockedApi.get.mockRejectedValue(new Error('Network error'));
+    server.use(http.get('*/api/satellite/frames/stats', () => HttpResponse.error()));
     renderWithProviders(<StatsTab />);
     await waitFor(() => {
       expect(screen.getByText('Failed to load statistics.')).toBeInTheDocument();
@@ -35,17 +29,22 @@ describe('StatsTab', () => {
   });
 
   it('renders with full stats data', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: {
-        total_frames: 1234,
-        total_size_bytes: 5_000_000,
-        by_satellite: {
-          'GOES-16': { count: 800, size: 3_000_000 },
-          'GOES-18': { count: 434, size: 2_000_000 },
-        },
-        by_band: { C02: { count: 500, size: 2_000_000 }, C13: { count: 734, size: 3_000_000 } },
-      },
-    });
+    server.use(
+      http.get('*/api/satellite/frames/stats', () =>
+        HttpResponse.json({
+          total_frames: 1234,
+          total_size_bytes: 5_000_000,
+          by_satellite: {
+            'GOES-16': { count: 800, size: 3_000_000 },
+            'GOES-18': { count: 434, size: 2_000_000 },
+          },
+          by_band: {
+            C02: { count: 500, size: 2_000_000 },
+            C13: { count: 734, size: 3_000_000 },
+          },
+        }),
+      ),
+    );
     renderWithProviders(<StatsTab />);
     await waitFor(() => {
       expect(screen.getByText('1,234')).toBeInTheDocument();
@@ -58,14 +57,7 @@ describe('StatsTab', () => {
   });
 
   it('handles stats with empty by_satellite and by_band', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: {
-        total_frames: 0,
-        total_size_bytes: 0,
-        by_satellite: {},
-        by_band: {},
-      },
-    });
+    // Default handlers serve empty stats already.
     renderWithProviders(<StatsTab />);
     await waitFor(() => {
       expect(screen.getByText('No statistics yet')).toBeInTheDocument();
@@ -73,14 +65,16 @@ describe('StatsTab', () => {
   });
 
   it('handles stats with null by_satellite and by_band (defensive)', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: {
-        total_frames: 10,
-        total_size_bytes: 1024,
-        by_satellite: null,
-        by_band: null,
-      },
-    });
+    server.use(
+      http.get('*/api/satellite/frames/stats', () =>
+        HttpResponse.json({
+          total_frames: 10,
+          total_size_bytes: 1024,
+          by_satellite: null,
+          by_band: null,
+        }),
+      ),
+    );
     renderWithProviders(<StatsTab />);
     await waitFor(() => {
       expect(screen.getByText('10')).toBeInTheDocument();
@@ -90,12 +84,14 @@ describe('StatsTab', () => {
   });
 
   it('handles stats with undefined by_satellite and by_band (defensive)', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: {
-        total_frames: 5,
-        total_size_bytes: 512,
-      },
-    });
+    server.use(
+      http.get('*/api/satellite/frames/stats', () =>
+        HttpResponse.json({
+          total_frames: 5,
+          total_size_bytes: 512,
+        }),
+      ),
+    );
     renderWithProviders(<StatsTab />);
     await waitFor(() => {
       expect(screen.getByText('5')).toBeInTheDocument();
@@ -103,7 +99,7 @@ describe('StatsTab', () => {
   });
 
   it('renders nothing when stats is null/undefined', async () => {
-    mockedApi.get.mockResolvedValue({ data: null });
+    server.use(http.get('*/api/satellite/frames/stats', () => HttpResponse.json(null)));
     const { container } = renderWithProviders(<StatsTab />);
     await waitFor(() => {
       // Component returns null when !stats
@@ -112,14 +108,16 @@ describe('StatsTab', () => {
   });
 
   it('handles single satellite with zero size (division edge case)', async () => {
-    mockedApi.get.mockResolvedValue({
-      data: {
-        total_frames: 1,
-        total_size_bytes: 0,
-        by_satellite: { 'GOES-16': { count: 1, size: 0 } },
-        by_band: { C02: { count: 1, size: 0 } },
-      },
-    });
+    server.use(
+      http.get('*/api/satellite/frames/stats', () =>
+        HttpResponse.json({
+          total_frames: 1,
+          total_size_bytes: 0,
+          by_satellite: { 'GOES-16': { count: 1, size: 0 } },
+          by_band: { C02: { count: 1, size: 0 } },
+        }),
+      ),
+    );
     renderWithProviders(<StatsTab />);
     await waitFor(() => {
       expect(screen.getByText('GOES-16')).toBeInTheDocument();

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,0 +1,183 @@
+/**
+ * Mock Service Worker handlers for frontend tests.
+ *
+ * These handlers intercept HTTP calls made by the axios `api` client during
+ * vitest runs. They provide sensible empty/default payloads for the
+ * most-used endpoints so component tests can render without needing to
+ * stub every axios method manually.
+ *
+ * Test files can compose on top of these with `server.use(...)` to layer
+ * endpoint-specific responses (see `msw` docs for request-level overrides).
+ *
+ * Where possible, response shapes are typed from `generated-types.ts`
+ * (re-exported via `../../api/types.ts`) so handler payloads stay in
+ * lockstep with the backend OpenAPI contract — a regression in the
+ * backend schema surfaces here as a type error rather than a silent test
+ * failure.
+ */
+import { http, HttpResponse } from 'msw';
+import type { components } from '../../api/generated-types';
+import type { Paginated } from '../../api/types';
+
+type GoesFrameResponse = components['schemas']['GoesFrameResponse'];
+type FrameStatsResponse = components['schemas']['FrameStatsResponse'];
+type JobResponse = components['schemas']['JobResponse'];
+type PresetResponse = components['schemas']['PresetResponse'];
+
+const API = '*/api';
+
+// ── Empty payload factories ─────────────────────────────────────────────
+// Exported so individual tests can build on them with server.use().
+
+export function emptyPaginatedFrames(): Paginated<GoesFrameResponse> {
+  return { items: [], total: 0, page: 1, limit: 50 };
+}
+
+export function emptyFrameStats(): FrameStatsResponse {
+  return {
+    total_frames: 0,
+    total_size_bytes: 0,
+    by_satellite: {},
+    by_band: {},
+  };
+}
+
+export function emptyProducts() {
+  return { satellites: [], bands: [], sectors: [] };
+}
+
+export function emptyCleanupStats() {
+  return {
+    total_frames: 0,
+    total_size_bytes: 0,
+    oldest_frame: null,
+    newest_frame: null,
+  };
+}
+
+export function emptyPaginatedJobs(): Paginated<JobResponse> {
+  return { items: [], total: 0, page: 1, limit: 50 };
+}
+
+// ── Default handlers ────────────────────────────────────────────────────
+
+export const handlers = [
+  // Frames & stats
+  http.get(`${API}/satellite/frames`, () => HttpResponse.json(emptyPaginatedFrames())),
+  http.get(`${API}/satellite/frames/stats`, () => HttpResponse.json(emptyFrameStats())),
+  http.get(`${API}/satellite/frames/:id`, ({ params }) =>
+    HttpResponse.json({
+      id: params.id,
+      satellite: 'GOES-16',
+      sector: 'CONUS',
+      band: 'C02',
+      capture_time: '2024-06-01T12:00:00Z',
+      file_size: 0,
+      width: null,
+      height: null,
+      image_url: null,
+      thumbnail_url: null,
+      source_job_id: null,
+      created_at: null,
+      tags: [],
+      collections: [],
+    }),
+  ),
+  http.delete(`${API}/satellite/frames/:id`, () => HttpResponse.json({ ok: true })),
+
+  // Products / catalog
+  http.get(`${API}/satellite/products`, () => HttpResponse.json(emptyProducts())),
+  http.get(`${API}/satellite/catalog/latest`, () => HttpResponse.json(null)),
+  http.get(`${API}/satellite/latest`, () => HttpResponse.json([])),
+
+  // Tags & collections
+  http.get(`${API}/satellite/tags`, () => HttpResponse.json([])),
+  http.post(`${API}/satellite/tags`, () =>
+    HttpResponse.json({ id: 'tag-1', name: 'new', color: '#808080' }),
+  ),
+  http.get(`${API}/satellite/collections`, () => HttpResponse.json([])),
+  http.post(`${API}/satellite/collections`, async ({ request }) => {
+    const body = (await request.json()) as { name?: string } | null;
+    return HttpResponse.json({ id: 'col-1', name: body?.name ?? 'new', frame_count: 0 });
+  }),
+  http.put(`${API}/satellite/collections/:id`, async ({ request, params }) => {
+    const body = (await request.json()) as { name?: string } | null;
+    return HttpResponse.json({ id: params.id, name: body?.name ?? 'renamed', frame_count: 0 });
+  }),
+  http.delete(`${API}/satellite/collections/:id`, () => HttpResponse.json({ ok: true })),
+
+  // Cleanup
+  http.get(`${API}/satellite/cleanup-rules`, () => HttpResponse.json([])),
+  http.post(`${API}/satellite/cleanup-rules`, () => HttpResponse.json({ id: 'rule-1' })),
+  http.get(`${API}/satellite/cleanup/stats`, () => HttpResponse.json(emptyCleanupStats())),
+  http.get(`${API}/satellite/cleanup/preview`, () =>
+    HttpResponse.json({ frames_to_delete: 0, bytes_to_free: 0, frames: [] }),
+  ),
+  http.post(`${API}/satellite/cleanup/run`, () =>
+    HttpResponse.json({ deleted: 0, bytes_freed: 0 }),
+  ),
+
+  // Fetch presets & schedules
+  http.get(`${API}/satellite/fetch-presets`, () => HttpResponse.json([])),
+  http.post(`${API}/satellite/fetch-presets`, () => HttpResponse.json({ id: 'p-1' })),
+  http.get(`${API}/satellite/schedules`, () => HttpResponse.json([])),
+  http.post(`${API}/satellite/schedules`, () => HttpResponse.json({ id: 's-1' })),
+
+  // Gaps / backfill
+  http.get(`${API}/satellite/gaps`, () => HttpResponse.json({ gaps: [] })),
+  http.post(`${API}/satellite/backfill`, () => HttpResponse.json({ job_id: 'bf-1' })),
+
+  // Fetch jobs
+  http.post(`${API}/satellite/fetch`, () =>
+    HttpResponse.json({ job_id: 'job-1', status: 'pending' }),
+  ),
+
+  // Composites
+  http.get(`${API}/satellite/composite-recipes`, () => HttpResponse.json([])),
+  http.get(`${API}/satellite/composites`, () =>
+    HttpResponse.json({ items: [], total: 0, page: 1, limit: 20 }),
+  ),
+  http.post(`${API}/satellite/composites`, () => HttpResponse.json({ id: 'c-1' })),
+  http.delete(`${API}/satellite/composites/:id`, () => HttpResponse.json({ ok: true })),
+
+  // Animations
+  http.get(`${API}/satellite/animations`, () =>
+    HttpResponse.json({ items: [], total: 0, page: 1, limit: 50 }),
+  ),
+  http.post(`${API}/satellite/animations`, () => HttpResponse.json({ id: 'anim-1' })),
+  http.get(`${API}/satellite/crop-presets`, () => HttpResponse.json([])),
+
+  // Jobs
+  http.get(`${API}/jobs`, () => HttpResponse.json(emptyPaginatedJobs())),
+  http.post(`${API}/jobs`, () => HttpResponse.json({ id: 'job-1', status: 'pending' })),
+  http.get(`${API}/jobs/:id`, ({ params }) =>
+    HttpResponse.json({ id: params.id, status: 'pending', progress: 0, logs: [] }),
+  ),
+  http.delete(`${API}/jobs/:id`, () => HttpResponse.json({ ok: true })),
+  http.post(`${API}/jobs/:id/cancel`, () => HttpResponse.json({ ok: true })),
+
+  // Presets (processing)
+  http.get(`${API}/presets`, () => HttpResponse.json([] as PresetResponse[])),
+  http.post(`${API}/presets`, () =>
+    HttpResponse.json({ id: 'preset-1', name: 'new', params: {}, created_at: '2024-01-01' }),
+  ),
+  http.delete(`${API}/presets/:id`, () => HttpResponse.json({ ok: true })),
+
+  // Settings
+  http.get(`${API}/settings`, () => HttpResponse.json({})),
+  http.put(`${API}/settings`, () => HttpResponse.json({})),
+  http.post(`${API}/settings`, () => HttpResponse.json({})),
+
+  // Notifications
+  http.get(`${API}/notifications`, () => HttpResponse.json([])),
+  http.post(`${API}/notifications/:id/read`, () => HttpResponse.json({ ok: true })),
+  http.delete(`${API}/notifications/:id`, () => HttpResponse.json({ ok: true })),
+
+  // Health / status / version
+  http.get(`${API}/health`, () => HttpResponse.json({ status: 'ok' })),
+  http.get(`${API}/status`, () => HttpResponse.json({ status: 'ok' })),
+  http.get(`${API}/version`, () => HttpResponse.json({ version: 'test' })),
+  http.get(`${API}/system/resources`, () =>
+    HttpResponse.json({ cpu_percent: 0, memory_percent: 0, disk_percent: 0 }),
+  ),
+];

--- a/frontend/src/test/mocks/msw.ts
+++ b/frontend/src/test/mocks/msw.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-file MSW helper for tests that want to intercept HTTP at the
+ * network layer instead of mocking the axios `api` client directly.
+ *
+ * Usage (inside a test file):
+ *
+ *   import { setupMswServer } from './mocks/msw';
+ *   const server = setupMswServer();
+ *
+ *   it('loads frames', () => {
+ *     server.use(http.get('*\/api/satellite/frames', () => HttpResponse.json(...)));
+ *     // ... render + assert
+ *   });
+ *
+ * The helper scopes server.listen()/close() to a single describe block by
+ * calling vitest lifecycle hooks at import time, which keeps MSW off the
+ * hot path of the ~220 legacy test files that still mock axios directly.
+ * (Starting MSW globally in `setup.ts` was causing libuv stream
+ * assertions on Node 24 + happy-dom; opting in per file avoids that.)
+ */
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+/**
+ * Start a fresh MSW server pre-loaded with the default handlers from
+ * `./handlers.ts`. The returned server has lifecycle hooks wired up so
+ * it starts before the enclosing test suite runs and resets between
+ * tests.
+ *
+ * The test file should not mock `../api/client` — let requests flow
+ * through axios so MSW can intercept them at the XHR layer.
+ */
+export function setupMswServer() {
+  const server = setupServer(...handlers);
+
+  beforeAll(() => {
+    server.listen({
+      // `warn` (not `error`) so unmocked endpoints log but don't fail —
+      // tests can still assert on specific requests without having to
+      // register a handler for every incidental call the component
+      // makes (e.g. /api/version, /api/status).
+      onUnhandledRequest: 'warn',
+    });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  return server;
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,7 +2,9 @@ import '@testing-library/jest-dom';
 import { afterEach, vi } from 'vitest';
 
 // Global fetch mock — prevents jsdom/undici "invalid onError method" unhandled rejections
-// that occur when components make HTTP requests during tests.
+// that occur when components make HTTP requests during tests. This is the default for
+// legacy tests that mock the axios `api` client directly; see `./mocks/msw.ts` for
+// tests that opt into the MSW-based HTTP interception pattern instead.
 const mockFetch = vi.fn(() =>
   Promise.resolve(
     new Response(JSON.stringify({}), {

--- a/frontend/src/test/useWebSocket.test.ts
+++ b/frontend/src/test/useWebSocket.test.ts
@@ -8,22 +8,29 @@ vi.mock('../api/ws', () => ({
   getWsApiKey: () => '',
 }));
 
+// Silence `reportError` side effects (writes to localStorage / console)
+// so the test output stays clean.
+vi.mock('../utils/errorReporter', () => ({
+  reportError: vi.fn(),
+}));
+
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
   url: string;
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
   onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
   readyState = 0;
+  sent: string[] = [];
 
   constructor(url: string) {
     this.url = url;
     MockWebSocket.instances.push(this);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  send(_data: string) {
-    // no-op for tests
+  send(data: string) {
+    this.sent.push(data);
   }
 
   close() {
@@ -38,6 +45,14 @@ class MockWebSocket {
 
   simulateMessage(data: unknown) {
     this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  simulateRawMessage(raw: string) {
+    this.onmessage?.({ data: raw });
+  }
+
+  simulateError() {
+    this.onerror?.();
   }
 }
 
@@ -143,6 +158,123 @@ describe('useWebSocket', () => {
       MockWebSocket.instances[0].simulateMessage({ type: 'ping' });
     });
     expect(result.current.data).toBeNull();
+  });
+
+  it('exponential backoff doubles between retries', () => {
+    renderHook(() => useWebSocket('job-123'));
+    act(() => MockWebSocket.instances[0].simulateOpen());
+
+    // First close → should queue a retry at 1000ms (2^0 * 1000)
+    act(() => MockWebSocket.instances[0].close());
+    expect(MockWebSocket.instances.length).toBe(1);
+    // 999ms is too early
+    act(() => vi.advanceTimersByTime(999));
+    expect(MockWebSocket.instances.length).toBe(1);
+    // 1ms more crosses the threshold
+    act(() => vi.advanceTimersByTime(1));
+    expect(MockWebSocket.instances.length).toBe(2);
+
+    // Second close → should wait 2000ms (2^1 * 1000)
+    act(() => MockWebSocket.instances[1].close());
+    act(() => vi.advanceTimersByTime(1999));
+    expect(MockWebSocket.instances.length).toBe(2);
+    act(() => vi.advanceTimersByTime(1));
+    expect(MockWebSocket.instances.length).toBe(3);
+
+    // Third close → should wait 4000ms (2^2 * 1000)
+    act(() => MockWebSocket.instances[2].close());
+    act(() => vi.advanceTimersByTime(3999));
+    expect(MockWebSocket.instances.length).toBe(3);
+    act(() => vi.advanceTimersByTime(1));
+    expect(MockWebSocket.instances.length).toBe(4);
+  });
+
+  it('stops reconnecting after maxRetries is reached', () => {
+    const { result } = renderHook(() => useWebSocket('job-123', 2));
+
+    // Close → retry 1 (delay 1000)
+    act(() => MockWebSocket.instances[0].close());
+    act(() => vi.advanceTimersByTime(1000));
+    expect(MockWebSocket.instances.length).toBe(2);
+
+    // Close → retry 2 (delay 2000)
+    act(() => MockWebSocket.instances[1].close());
+    act(() => vi.advanceTimersByTime(2000));
+    expect(MockWebSocket.instances.length).toBe(3);
+
+    // Third close → retriesRef is now 2 and maxRetries is 2 → stop
+    act(() => MockWebSocket.instances[2].close());
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(MockWebSocket.instances.length).toBe(3);
+    expect(result.current.reconnecting).toBe(false);
+  });
+
+  it('closes socket and clears timer on unmount', () => {
+    const { unmount } = renderHook(() => useWebSocket('job-123'));
+    const ws = MockWebSocket.instances[0];
+    const closeSpy = vi.spyOn(ws, 'close');
+
+    // Queue up a reconnect timer
+    act(() => ws.simulateOpen());
+    act(() => ws.close());
+
+    // Unmount before the reconnect timer fires
+    unmount();
+
+    // Advance past the scheduled retry — no new socket should be created
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(closeSpy).toHaveBeenCalled();
+    expect(MockWebSocket.instances.length).toBe(1);
+  });
+
+  it('ignores connected/ping handshake messages', () => {
+    const { result } = renderHook(() => useWebSocket('job-123'));
+    act(() => MockWebSocket.instances[0].simulateOpen());
+
+    act(() => MockWebSocket.instances[0].simulateMessage({ type: 'connected' }));
+    act(() => MockWebSocket.instances[0].simulateMessage({ type: 'ping' }));
+    expect(result.current.data).toBeNull();
+
+    // But a real progress message does land in data
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'progress',
+        progress: 10,
+        message: 'tick',
+      }),
+    );
+    expect(result.current.data?.progress).toBe(10);
+  });
+
+  it('handles malformed JSON without throwing', () => {
+    const { result } = renderHook(() => useWebSocket('job-123'));
+    act(() => MockWebSocket.instances[0].simulateOpen());
+
+    expect(() => {
+      act(() => MockWebSocket.instances[0].simulateRawMessage('not { valid json'));
+    }).not.toThrow();
+    expect(result.current.data).toBeNull();
+  });
+
+  it('fills in defaults for log entries with missing fields', () => {
+    const { result } = renderHook(() => useWebSocket('job-123'));
+    act(() => MockWebSocket.instances[0].simulateOpen());
+
+    act(() => {
+      MockWebSocket.instances[0].simulateMessage({ type: 'log' });
+    });
+    expect(result.current.logs).toHaveLength(1);
+    expect(result.current.logs[0].level).toBe('info');
+    expect(result.current.logs[0].message).toBe('');
+    // Timestamp should be filled with a non-empty ISO string
+    expect(result.current.logs[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('calls ws.onerror handler without throwing', () => {
+    renderHook(() => useWebSocket('job-123'));
+    expect(() => {
+      act(() => MockWebSocket.instances[0].simulateError());
+    }).not.toThrow();
   });
 
   it('should clear stale data and logs when jobId changes', () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,11 +29,24 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
+      // Exclude test-only files (fixtures, MSW handlers, harness helpers)
+      // from the coverage denominator — they're test infrastructure, not
+      // production code, and shouldn't count against the threshold.
+      exclude: [
+        'src/test/**',
+        'src/**/*.test.ts',
+        'src/**/*.test.tsx',
+        'src/**/__tests__/**',
+        '**/*.d.ts',
+        'src/main.tsx',
+        'src/vite-env.d.ts',
+        'src/api/generated-types.ts',
+      ],
       thresholds: {
-        lines: 56,
-        functions: 56,
-        branches: 56,
-        statements: 56,
+        lines: 70,
+        functions: 70,
+        branches: 70,
+        statements: 70,
       },
     },
   },


### PR DESCRIPTION
## Summary

Bundles JTN-388 (Mock Service Worker adoption) and JTN-401 (coverage gate raise + WebSocket tests) into one PR.

## JTN-388 — MSW adoption

- Added `msw@2.13.2` to `frontend/devDependencies`
- New `src/test/mocks/handlers.ts` with default handlers for the most-used backend endpoints (frames, stats, products, collections, tags, cleanup rules, presets, schedules, composites, animations, jobs, notifications, health), typed from the generated OpenAPI schema where possible
- New `src/test/mocks/msw.ts` exporting a `setupMswServer()` helper that scopes `server.listen()/close()` per test file. This opt-in pattern sidesteps a libuv stream-destroy assertion that fires on Node 24 + happy-dom when MSW interceptors are combined with happy-dom's `WebSocket` implementation — CI is on Node 20 so this is a local-dev guardrail, not a CI fix
- Migrated the worst `as any` / `as unknown` offenders (11 test files) to MSW:
  - `BrowseTabDefensive`, `CleanupTab`, `CleanupTabDefensive`, `CleanupTabExtended`
  - `CollectionsTabDefensive`, `CollectionsTabExtended`
  - `CompositesTab`, `CompositesTabDefensive`
  - `GapsTab`, `GoesDataExtended`
  - `NotificationBellDefensive`, `PresetsTabDefensive`, `StatsTab`

### Cast counts

| | Before | After |
|---|---|---|
| `as any` / `as unknown` occurrences | 73 | 60 |
| Test files with casts | 46 | 33 |

### Follow-ups (deliberately out of scope)

- LiveTab-family tests and `HimawariUxScheduling` use complex `mockedApi.post.mock.calls.find(...)` assertions that benefit from a dedicated migration pass (one per file)
- `AnimationStudioTab` (311 LOC of interwoven mocks) should get its own PR
- `useImageZoom` / `useSwipeBand` / `useImageZoomClamping` casts are DOM event fixtures (`{ touches, preventDefault } as unknown as React.TouchEvent`), not axios mocks — different migration pattern

## JTN-401 — Coverage gate + WebSocket tests

- Extended `useWebSocket.test.ts` from 9 → 16 tests covering:
  - Exponential backoff doubles between retries (1s → 2s → 4s)
  - `maxRetries` exhaustion stops the reconnect loop
  - Unmount during a pending reconnect closes the socket and clears the timer
  - `connected` / `ping` handshake messages don't pollute `data`
  - Malformed JSON is caught without throwing
  - Log entries with missing fields get sensible defaults
  - `onerror` handler runs without throwing
- Bumped vitest coverage thresholds in `vite.config.ts` from 56% → 70%
- Excluded `src/test/**`, `*.test.{ts,tsx}`, generated types, and entry points from the coverage denominator so test-only fixtures don't count against the threshold

### Coverage before vs. after

| Metric | Before (56% gate) | After (70% gate) |
|---|---|---|
| Statements | 78.24 | **78.94** |
| Branches | 76.92 | **77.06** |
| Functions | 69.68 | **71.19** |
| Lines | 79.90 | **80.72** |

Notable per-file improvement: `useWebSocket.ts` line coverage climbed to **98.6%**.

## Test plan

- [x] `npx vitest run` — 228 files / 1947 tests passing (baseline was 1940)
- [x] `npx vitest run --coverage` — exit 0, all four metrics above 70%
- [x] `npm run lint` — 0 errors (117 pre-existing warnings unchanged)
- [x] `npm run build` — succeeds
- [x] No tests skipped / `@ts-ignore` / `--no-verify` used
- [ ] CI: test + lint + build pass
- [ ] CodeRabbit review
- [ ] Sonar: 0 new issues, ≥80% new-code coverage

## Notes on the websocket "pre-broken" memory

The project memory note said websocket tests were pre-broken; investigation shows that's no longer true — all 9 original `useWebSocket` tests pass and now form the base we built on top of. Leaving the memory note update to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)