### PR TITLE
fix(ci): single CI Gate context so path-skipped PRs can merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,12 @@ jobs:
               - 'requirements*.txt'
               - 'backend/requirements.in'
               - 'backend/requirements.lock'
+              # Workflow edits must run the full suite: skipping on them left
+              # workflow-only PRs with no reported contexts at all.
+              - '.github/workflows/**'
             frontend:
               - 'frontend/**'
+              - '.github/workflows/**'
 
   lint-audit:
     name: Lint & Security Audit
@@ -1200,3 +1204,26 @@ jobs:
             exit 1
           fi
           echo "✅ All jobs passed (or were skipped due to path filters)"
+
+  # The one context branch protection requires (alongside the gitleaks
+  # workflow). Per-shard matrix contexts cannot be required directly: when a
+  # path filter skips a matrix job, GitHub reports a single skipped check
+  # named with the literal `${{ matrix.shard }}` — the per-shard names never
+  # appear, and PRs wait on them forever. This gate always runs and fails iff
+  # any needed job failed or was cancelled; path-skipped jobs count as pass.
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [changes, lint-audit, backend, integration, integration-smoke, frontend, frontend-build, e2e]
+    if: always()
+    steps:
+      - name: Check needed job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          bad=$(echo "$RESULTS" | jq '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled")] | length')
+          if [ "$bad" -ne 0 ]; then
+            echo "::error::$bad required job(s) failed or were cancelled"
+            exit 1
+          fi


### PR DESCRIPTION
Branch protection currently requires the per-shard matrix contexts (Backend Tests 1–4, Frontend Tests 1–2, E2E 1–3, …). When the path filter skips a matrix job, GitHub reports **one** skipped check named with the literal `${{ matrix.shard }}` placeholder — the per-shard names never report, so any PR that does not touch **both** backend and frontend waits on "Expected" checks forever. Workflow-only changes are worse: they matched no filter bucket, skipped everything, and reported no contexts at all. Every open dependabot PR was jammed on this.

Two changes:
1. **`ci-gate` job** — always runs, `needs:` every test job, fails iff any needed job failed or was cancelled (path-skipped jobs count as pass). This becomes the single required context alongside Gitleaks; equivalent strength to the old list, immune to matrix-skip naming.
2. **`.github/workflows/**` added to both filter buckets** — workflow edits now run the full suite.

Deployment (after merge): switch required contexts from the 15-entry list to `["Gitleaks Secret Scan", "CI Gate"]`, then rebase the queued dependabot PRs so they produce the gate context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation so changes to workflow configuration run the complete test suite.
  * Added a consolidated continuous integration status check that clearly reports failed or cancelled required checks while allowing intentionally skipped checks.
  * These improvements provide more consistent and reliable build results for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->